### PR TITLE
Fix mobile layout for statistics boxes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1017,13 +1017,21 @@ h1, h2, h3, h4, h5, h6 {
     }
 }
 
+/* Mobile breakpoint - broader coverage for all mobile devices including larger phones */
+@media (max-width: 900px) {
+    .testimonials-grid {
+        grid-template-columns: 1fr !important;
+        gap: 1.5rem;
+    }
+}
+
 @media (max-width: 768px) {
     .use-case-grid {
         grid-template-columns: 1fr;
     }
     
     .testimonials-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr !important;
         gap: 1.5rem;
     }
     


### PR DESCRIPTION
Fixes mobile UIUX issue where three statistics boxes were not displaying properly on mobile devices.

## Changes
- Added broader mobile breakpoint at 900px for better mobile device coverage
- Strengthened mobile CSS rules with !important to ensure proper stacking
- Statistics boxes now display in single column on all mobile devices

## Testing
The three boxes containing Produttività, ROI Superiore, and Trend di Mercato content now properly stack vertically on mobile devices.

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)