### PR TITLE
Fix mobile menu dropdown navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -283,7 +283,7 @@ h1, h2, h3, h4, h5, h6 {
     transition: transform var(--transition-fast);
 }
 
-.dropdown.active .dropdown-arrow {
+.nav-item.dropdown.active .dropdown-arrow {
     transform: rotate(180deg);
 }
 
@@ -304,8 +304,8 @@ h1, h2, h3, h4, h5, h6 {
     z-index: 1000;
 }
 
-.dropdown:hover .dropdown-menu,
-.dropdown.active .dropdown-menu {
+.nav-item.dropdown:hover .dropdown-menu,
+.nav-item.dropdown.active .dropdown-menu {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);
@@ -2691,7 +2691,7 @@ button[aria-busy="true"]::after {
         transition: all 0.3s ease;
     }
 
-    .dropdown.active .dropdown-menu {
+    .nav-item.dropdown.active .dropdown-menu {
         opacity: 1;
         visibility: visible;
         max-height: 200px;


### PR DESCRIPTION
Fixes #5

This PR resolves the issue where mobile menu submenus were not opening when tapped.

## Root Cause
The JavaScript was adding the `active` class to `.nav-item.dropdown` elements, but the CSS was looking for `.dropdown.active .dropdown-menu`. This selector mismatch meant the mobile dropdown styles were never applied.

## Solution
- Updated CSS selectors to match the HTML structure (`.nav-item.dropdown.active`)
- Fixed both desktop and mobile dropdown selectors for consistency
- Maintained existing hover behavior while fixing click behavior

## Testing
The mobile navigation dropdowns should now open correctly when tapped on mobile devices.

Generated with [Claude Code](https://claude.ai/code)