### PR TITLE
fix: correct mobile dropdown position to enable touch navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2679,7 +2679,7 @@ button[aria-busy="true"]::after {
 
     /* Mobile Dropdown Styles */
     .dropdown-menu {
-        position: static;
+        position: relative;
         box-shadow: none;
         background: var(--light-gray);
         margin-top: 0.5rem;


### PR DESCRIPTION
Fixes mobile menu dropdown navigation issue where dropdowns were not opening when tapped on mobile devices.

## Root Cause
The mobile CSS had `position: static` which broke dropdown functionality by removing the element from normal document flow.

## Solution
- Changed `position: static` to `position: relative` in mobile dropdown CSS
- Maintains proper parent-child relationship for visibility control
- JavaScript active class toggle now works correctly
- Preserves all existing desktop functionality

Generated with [Claude Code](https://claude.ai/code)