### PR TITLE
Change title from 'Prossimi Eventi' to 'Eventi Prossimi'

### DIFF
--- a/eventi.html
+++ b/eventi.html
@@ -120,7 +120,7 @@
     <!-- Prossimi Eventi -->
     <section id="prossimi-eventi" class="events-upcoming">
         <div class="container">
-            <h2 class="section-title">Prossimi Eventi</h2>
+            <h2 class="section-title">Eventi Prossimi</h2>
             <div class="events-grid" id="upcoming-events">
                 <!-- Eventi generati dinamicamente -->
             </div>


### PR DESCRIPTION
This PR changes the title on the eventi.html page from "Prossimi Eventi" to "Eventi Prossimi" as requested in issue #9.

Generated with [Claude Code](https://claude.ai/code)