### PR TITLE
fix: align partner logos in consistent 4x2 grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,22 +459,20 @@
                 <div class="partner-logo">
                     <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" />
                 </div>
-            </div>
-            <div class="partners-grid" style="margin-top: 40px;">
                 <div class="partner-logo">
-                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" style="max-height: 60px; width: auto;" />
+                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" />
                 </div>
                 <div class="partner-logo">
-                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" style="max-height: 60px; width: auto;" />
+                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" />
                 </div>
                 <div class="partner-logo">
-                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" style="max-height: 60px; width: auto;" />
+                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" />
                 </div>
                 <div class="partner-logo">
-                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" style="max-height: 60px; width: auto;" />
+                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" />
                 </div>
                 <div class="partner-logo">
-                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" style="max-height: 60px; width: auto;" />
+                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes # 11

Consolidated 8 partner logos into single partners-grid container for perfect alignment. Now displays 2 rows of 4 logos each instead of uneven distribution.

## Changes
- Merged two separate `partners-grid` divs into one
- Removed inline styles from AI partner logos
- Maintains existing mobile responsiveness

## Result
- Desktop: Perfect 4x2 grid layout
- Tablet: 2x4 grid layout
- Mobile: 1x8 grid layout

Generated with [Claude Code](https://claude.ai/code)