### PR TITLE
fix: Update LBBG section text in Chi Siamo page

### DIFF
--- a/chi-siamo.html
+++ b/chi-siamo.html
@@ -389,10 +389,7 @@
                     <div class="libera-info">
                         <h3>Perché Libera è Fondamentale per Niuexa</h3>
                         <p>
-                            <strong>Libera Brand Building Group</strong> è il nostro partner strategico che trasforma le soluzioni AI che creiamo per te in successi commerciali straordinari. Mentre Niuexa sviluppa la tecnologia più avanzata, Libera la rende irresistibile sul mercato.
-                        </p>
-                        <p>
-                            Questa partnership è il segreto dietro la rapida crescita di Niuexa: combiniamo l'eccellenza tecnologica AI con strategie di marketing che fanno letteralmente <strong>"crescere" i prodotti</strong> sul mercato, generando domanda massiva e ROI eccezionali.
+                            Niuexa è controllata da LBBG, attiva da oltre 20 anni nel mercato della comunicazione digitale con un fatturato annuale superiore ai 10M di euro. Questa partnership è il segreto della rapida crescita di Niuexa: combiniamo l'eccellenza tecnologica AI con strategie di marketing che fanno "crescere" i prodotti sul mercato, generando domanda e ROI.
                         </p>
                     </div>
                     <div class="libera-positioning">


### PR DESCRIPTION
Replace partnership description with new controlling entity description in the "Chi siamo" page, "Libera Brand Building Group" section.

**Changes:**
- Updated text to reflect that Niuexa is controlled by LBBG
- LBBG described as active for 20+ years with 10M+ euro revenue
- Maintained core messaging about AI technology and marketing strategies

Resolves #16

Generated with [Claude Code](https://claude.ai/code)