### PR TITLE
feat: Add favicon links to all pages missing them

### DIFF
--- a/carriere.html
+++ b/carriere.html
@@ -23,6 +23,13 @@
     <meta property="og:image" content="img/team_group_photo.jpg">
     <meta property="og:url" content="https://niuexaservizi.it/carriere.html">
     
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/certification.html
+++ b/certification.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/niuexa-certification.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/certification.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/chi-siamo.html
+++ b/chi-siamo.html
@@ -43,6 +43,13 @@
     <link rel="alternate" hreflang="it" href="https://niuexaservizi.it/chi-siamo.html">
     <link rel="alternate" hreflang="it-IT" href="https://niuexaservizi.it/chi-siamo.html">
     
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <title>Chi Siamo | Team e Fondatori - Niuexa Consulenza AI Milano</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/login.html
+++ b/login.html
@@ -15,6 +15,14 @@
     </script>
     
     <title>Client Login - Niuexa</title>
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-automazione-workflow-ai.html
+++ b/tutorial-automazione-workflow-ai.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-ai-automation.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-automazione-workflow-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-generazione-immagini-ai.html
+++ b/tutorial-generazione-immagini-ai.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-ai-image-generation.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-generazione-immagini-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-generazione-video-ai.html
+++ b/tutorial-generazione-video-ai.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-ai-video-generation.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-generazione-video-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-lead-generation-ai.html
+++ b/tutorial-lead-generation-ai.html
@@ -30,6 +30,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-lead-generation-ai.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-lead-generation-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-umanizzare-testi-ai.html
+++ b/tutorial-umanizzare-testi-ai.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-humanize-ai.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-umanizzare-testi-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/tutorial-voice-audio-ai.html
+++ b/tutorial-voice-audio-ai.html
@@ -32,6 +32,14 @@
     <meta property="twitter:image" content="https://niuexaservizi.it/img/tutorial-ai-audio.jpg">
 
     <link rel="canonical" href="https://niuexaservizi.it/tutorial-voice-audio-ai.html">
+    
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon 256.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon 256.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="img/favicon 256.ico">
+    <link rel="manifest" href="site.webmanifest">
+    
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Ensures consistent favicon display across the entire website by adding the standard favicon block to 10 pages that were missing it:

- carriere.html
- chi-siamo.html 
- certification.html
- login.html
- All tutorial pages (6 files)

Added favicon links match the homepage implementation with standard .ico favicon, Apple touch icon, and web manifest reference.

Fixes #27

Generated with [Claude Code](https://claude.ai/code)