### PR TITLE
Remove FAQ question "Offrite supporto post-corso?" from training page

### DIFF
--- a/training.html
+++ b/training.html
@@ -200,14 +200,6 @@
                     "@type": "Answer",
                     "text": "Assolutamente sì! Offriamo analisi preliminare delle esigenze aziendali, personalizzazione contenuti e casi studio, formazione su misura per il vostro settore e mentorship post-corso dedicata."
                 }
-            },
-            {
-                "@type": "Question",
-                "name": "Che tipo di supporto è incluso nei corsi AI?",
-                "acceptedAnswer": {
-                    "@type": "Answer",
-                    "text": "Il supporto completo include: community esclusiva di alumni, sessioni Q&A mensili, aggiornamenti su nuove tecnologie, supporto tecnico via email e webinar gratuiti di approfondimento."
-                }
             }
         ]
     }
@@ -816,24 +808,6 @@
                         </div>
                     </div>
 
-                    <div class="faq-item">
-                        <h3 class="faq-question">
-                            <button class="faq-toggle" onclick="toggleFAQ(this)">
-                                Offrite supporto post-corso?
-                                <span class="faq-icon">+</span>
-                            </button>
-                        </h3>
-                        <div class="faq-answer">
-                            <p>Sì, il supporto post-corso è incluso:</p>
-                            <ul>
-                                <li>Community esclusiva di alumni</li>
-                                <li>Sessioni Q&A mensili</li>
-                                <li>Aggiornamenti su nuove tecnologie</li>
-                                <li>Supporto tecnico via email</li>
-                                <li>Webinar gratuiti di approfondimento</li>
-                            </ul>
-                        </div>
-                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Remove the last FAQ question about post-course support from the training page as requested in issue #33.

Changes:
- Removed FAQ question and answer from HTML
- Removed corresponding entry from FAQ schema markup

Closes #33

Generated with [Claude Code](https://claude.ai/code)