### PR TITLE
Rimossa scritta 'Previsioni vendite' da Agente Vendite AI

### DIFF
--- a/products.html
+++ b/products.html
@@ -464,10 +464,6 @@
                             </li>
                             <li style="padding: 0.6rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; line-height: 1.5;">
                                 <span style="position: absolute; left: 0; color: #00cc66; font-weight: bold; font-size: 1.1rem;">✓</span>
-                                <strong>Previsioni vendite:</strong> Analisi predittiva opportunità di chiusura
-                            </li>
-                            <li style="padding: 0.6rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; line-height: 1.5;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-weight: bold; font-size: 1.1rem;">✓</span>
                                 <strong>Integrazione CRM completa:</strong> Salesforce, HubSpot, Pipedrive
                             </li>
                             <li style="padding: 0.6rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; line-height: 1.5;">


### PR DESCRIPTION
Risolve #35

Rimozione della scritta "Previsioni vendite: Analisi predittiva opportunità di chiusura" dal box Agente Vendite AI nella pagina prodotti come richiesto.

Generated with [Claude Code](https://claude.ai/code)