### PR TITLE
Remove GDPR and ISO 27001 certification text from FAQ

### DIFF
--- a/products.html
+++ b/products.html
@@ -236,7 +236,7 @@
                 "name": "Come viene garantita la sicurezza dei dati con gli agenti AI?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "Sicurezza enterprise: crittografia end-to-end AES-256, conformità GDPR e ISO 27001 certificata, data center europei certificati, backup automatici e disaster recovery, audit di sicurezza periodici."
+                    "text": "Sicurezza enterprise: crittografia end-to-end AES-256, data center europei certificati, backup automatici e disaster recovery, audit di sicurezza periodici."
                 }
             },
             {
@@ -816,7 +816,6 @@
                         <p>Sicurezza di livello enterprise:</p>
                         <ul>
                             <li>Crittografia end-to-end AES-256</li>
-                            <li>Conformità GDPR e ISO 27001 certificata</li>
                             <li>Data center europei certificati</li>
                             <li>Backup automatici e disaster recovery</li>
                             <li>Audit di sicurezza periodici</li>


### PR DESCRIPTION
Fixes #37

Removed "Conformità GDPR e ISO 27001 certificata" from the Products page FAQ section as requested.

## Changes
- Updated JSON schema structured data for security FAQ
- Removed certification text from HTML FAQ list item

Generated with [Claude Code](https://claude.ai/code)