### PR TITLE
Remove Torino phone number from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,7 @@
                             <span class="contact-icon">📍</span>
                             <div>
                                 <h5>Torino</h5>
-                                <p>via Andreis 18/16/M<br>10152 Torino<br>011 4310815</p>
+                                <p>via Andreis 18/16/M<br>10152 Torino</p>
                             </div>
                         </div>
                         <div class="contact-item">


### PR DESCRIPTION
Fixes #39

Removed the phone number "011 4310815" from the Torino address in the "Preferisci i Metodi Tradizionali?" section on the homepage as requested.

Generated with [Claude Code](https://claude.ai/code)