### PR TITLE
fix: update certification text in impara.html

### DIFF
--- a/impara.html
+++ b/impara.html
@@ -465,7 +465,7 @@
                 <div class="cert-hub-header">
                     <div class="cert-hub-icon">🏆</div>
                     <h2>Ottieni le Tue Certificazioni AI</h2>
-                    <p>Valida le tue competenze e ottieni certificati ufficiali riconosciuti nel settore</p>
+                    <p>Valida le tue competenze e ottieni i certificati Niuexa</p>
                 </div>
                 
                 <div class="cert-hub-benefits">


### PR DESCRIPTION
Updated the certification section text in impara.html as requested in issue #43.

Changed 'certificati ufficiali riconosciuti nel settore' to 'i certificati Niuexa' in the "Ottieni le Tue Certificazioni AI" section.

Fixes #43

Generated with [Claude Code](https://claude.ai/code)