### PR TITLE
fix: update certification page subtitle text

### DIFF
--- a/certification.html
+++ b/certification.html
@@ -59,7 +59,7 @@
                 <div class="welcome-content">
                     <div class="cert-hero">
                         <h1 class="hero-title">Certificazione Niuexa AI</h1>
-                        <p class="hero-subtitle">Valida le tue competenze in intelligenza artificiale e ottieni un certificato ufficiale riconosciuto nel settore</p>
+                        <p class="hero-subtitle">Valida le tue competenze in intelligenza artificiale e ottieni il certificato ufficiale Niuexa</p>
                         <div class="hero-stats">
                             <div class="stat">
                                 <span class="stat-number">5</span>


### PR DESCRIPTION
Changes the subtitle text on the certification page from 'certificato ufficiale riconosciuto nel settore' to 'certificato ufficiale Niuexa' as requested in issue #45.

Generated with [Claude Code](https://claude.ai/code)