### PR TITLE
Remove navigation menu from landing page

### DIFF
--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -109,11 +109,6 @@
     </style>
 </head>
 <body>
-    <!-- Skip Navigation for Accessibility -->
-    <a href="#main-content" class="skip-nav">Vai sul contenuto principale</a>
-    
-    <!-- Navigation Placeholder -->
-    <div id="nav-placeholder"></div>
 
     <!-- Hero Section -->
     <section id="home" class="hero">
@@ -193,7 +188,6 @@
     <div id="footer-placeholder"></div>
 
     <!-- Scripts -->
-    <script src="includes/includes.js"></script>
     <script src="script.js"></script>
     <script src="cookie-banner.js"></script>
     <script>


### PR DESCRIPTION
Removes the navigation menu bar from landing-niuexa.html while preserving all other content

Changes:
- Removed nav placeholder div and includes.js script
- Removed skip navigation link (no longer needed)
- Preserved all other page content and functionality

Fixes #52

Generated with [Claude Code](https://claude.ai/code)