### PR TITLE
Add ElevenLabs footer bar to landing-niuexa.html

### DIFF
--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -199,6 +199,14 @@
     <!-- Footer Placeholder -->
     <div id="footer-placeholder"></div>
 
+    <!-- ElevenLabs Footer Bar -->
+    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; text-align: center; font-size: 0.9rem; color: var(--medium-gray);">
+        <div class="container">
+            © 2024 Niuexa. Tutti i diritti riservati. 
+            Powered by ElevenLabs <a href="https://elevenlabs.io/conversational-ai" target="_blank" rel="noopener noreferrer" style="color: var(--primary-blue); text-decoration: none;">Conversational AI</a>
+        </div>
+    </div>
+
     <!-- Scripts -->
     <script src="script.js"></script>
     <script src="cookie-banner.js"></script>


### PR DESCRIPTION
Fixes #56

Added footer bar with copyright and ElevenLabs attribution to the landing page:

- Added "© 2024 Niuexa. Tutti i diritti riservati."
- Added "Powered by ElevenLabs Conversational AI" with proper link
- Styled consistently with brand colors and design system
- Positioned after main footer as requested

Generated with [Claude Code](https://claude.ai/code)