### PR TITLE
Update Roberto Botto's Libera Brand Building info

### DIFF
--- a/chi-siamo.html
+++ b/chi-siamo.html
@@ -282,9 +282,9 @@
                                 <span>🌐</span>
                             </div>
                             <div class="social-content">
-                                <h4>Libera Brand Building</h4>
+                                <h4>Libera Brand Building Group</h4>
                                 <p>Brand Growth Partner</p>
-                                <a href="https://www.liberabrandbuilding.com" target="_blank" rel="noopener noreferrer">Visita il Sito</a>
+                                <a href="https://www.liberabrandbuilding.group/" target="_blank" rel="noopener noreferrer">Visita il Sito</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This PR updates Roberto Botto's co-founder section in the Chi siamo page:

- Changed 'Libera Brand Building' to 'Libera Brand Building Group'
- Updated website link to https://www.liberabrandbuilding.group/

Fixes #66

Generated with [Claude Code](https://claude.ai/code)