### PR TITLE
Update Principiante course details in training section

### DIFF
--- a/training.html
+++ b/training.html
@@ -95,11 +95,11 @@
                     "name": "Niuexa"
                 },
                 "educationalLevel": "Principiante",
-                "timeRequired": "PT8H",
+                "timeRequired": "PT16H",
                 "courseCode": "AI-FUND-001",
                 "offers": {
                     "@type": "Offer",
-                    "price": "1200",
+                    "price": "600",
                     "priceCurrency": "EUR"
                 }
             },
@@ -234,7 +234,7 @@
                         "name": "AI Executive Mastery",
                         "description": "Corso per manager e team leader sull'intelligenza artificiale"
                     },
-                    "price": "1200",
+                    "price": "600",
                     "priceCurrency": "EUR"
                 },
                 {
@@ -387,7 +387,7 @@
                         <div class="program-details">
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">⏱️</span>
-                                <span itemprop="timeRequired">Durata: 8 ore (2 giorni)</span>
+                                <span itemprop="timeRequired">Durata: 16 ore (2 giornate consecutive)</span>
                             </div>
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">👥</span>
@@ -424,12 +424,11 @@
                         </div>
                         
                         <div class="program-price">
-                            <span class="price-original">€1,500</span>
                             <span class="price-current" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                                <span itemprop="price">€1,200</span>
+                                <span itemprop="price">600 euro</span>
                                 <span itemprop="priceCurrency" content="EUR">/persona</span>
                             </span>
-                            <span class="price-save">Risparmia €300</span>
+                            <span class="price-save">Minimo 10 persone</span>
                         </div>
                         
                         <div class="program-actions">


### PR DESCRIPTION
Updates the Principiante course information as requested in issue #68:

- Change duration from '8 ore (2 giorni)' to '16 ore (2 giornate consecutive)'
- Remove crossed-out price '€1,500'
- Update price from '€1,200 /persona' to '600 euro /persona'
- Change savings text from 'Risparmia €300' to 'Minimo 10 persone'
- Update structured data schema to reflect new duration and price

Resolves #68

Generated with [Claude Code](https://claude.ai/code)