### PR TITLE
Update training course information

### DIFF
--- a/training.html
+++ b/training.html
@@ -112,11 +112,11 @@
                     "name": "Niuexa"
                 },
                 "educationalLevel": "Intermedio",
-                "timeRequired": "PT12H",
+                "timeRequired": "PT24H",
                 "courseCode": "AI-PROMPT-001",
                 "offers": {
                     "@type": "Offer",
-                    "price": "1800",
+                    "price": "900",
                     "priceCurrency": "EUR"
                 }
             },
@@ -129,11 +129,11 @@
                     "name": "Niuexa"
                 },
                 "educationalLevel": "Avanzato",
-                "timeRequired": "PT16H",
+                "timeRequired": "PT32H",
                 "courseCode": "AI-AGENT-001",
                 "offers": {
                     "@type": "Offer",
-                    "price": "2500",
+                    "price": "1200",
                     "priceCurrency": "EUR"
                 }
             }
@@ -244,7 +244,7 @@
                         "name": "Prompt Engineering Avanzato",
                         "description": "Tecniche avanzate per massimizzare l'efficacia dell'AI"
                     },
-                    "price": "1800",
+                    "price": "900",
                     "priceCurrency": "EUR"
                 },
                 {
@@ -254,7 +254,7 @@
                         "name": "AI Agent Developer Certification",
                         "description": "Sviluppo e gestione di agenti AI enterprise"
                     },
-                    "price": "2500",
+                    "price": "1200",
                     "priceCurrency": "EUR"
                 }
             ]
@@ -480,7 +480,7 @@
                         <div class="program-details">
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">⏱️</span>
-                                <span itemprop="timeRequired">Durata: 12 ore (3 giorni)</span>
+                                <span itemprop="timeRequired">Durata: 24 ore (3 giornate anche non consecutive)</span>
                             </div>
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">👥</span>
@@ -517,12 +517,11 @@
                         </div>
                         
                         <div class="program-price">
-                            <span class="price-original">€2,200</span>
                             <span class="price-current" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                                <span itemprop="price">€1,800</span>
+                                <span itemprop="price">900 euro</span>
                                 <span itemprop="priceCurrency" content="EUR">/persona</span>
                             </span>
-                            <span class="price-save">Risparmia €400</span>
+                            <span class="price-save">Minimo 10 persone</span>
                         </div>
                         
                         <div class="program-actions">
@@ -560,11 +559,11 @@
                         <div class="program-details">
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">⏱️</span>
-                                <span itemprop="timeRequired">Durata: 16 ore (4 giorni)</span>
+                                <span itemprop="timeRequired">Durata: 32 ore (4 giornate anche non consecutive)</span>
                             </div>
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">👥</span>
-                                <span>Max 8 partecipanti</span>
+                                <span>Max 10 partecipanti</span>
                             </div>
                             <div class="detail-item">
                                 <span class="detail-icon" aria-hidden="true">🏆</span>
@@ -597,12 +596,11 @@
                         </div>
                         
                         <div class="program-price">
-                            <span class="price-original">€3,000</span>
                             <span class="price-current" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                                <span itemprop="price">€2,500</span>
+                                <span itemprop="price">1200 euro</span>
                                 <span itemprop="priceCurrency" content="EUR">/persona</span>
                             </span>
-                            <span class="price-save">Risparmia €500</span>
+                            <span class="price-save">Minimo 10 persone</span>
                         </div>
                         
                         <div class="program-actions">


### PR DESCRIPTION
Updates course information for Corso Intermedio and Corso Avanzato as requested in issue #70.

## Changes Made

**Corso Intermedio (Prompt Engineering Avanzato):**
- Updated duration to 24 hours (3 non-consecutive days)
- Removed strikethrough price
- Changed price to 900 euro/persona
- Updated to "Minimo 10 persone"

**Corso Avanzato (AI Agent Developer Certification):**
- Updated duration to 32 hours (4 non-consecutive days)
- Increased max participants to 10
- Removed strikethrough price
- Changed price to 1200 euro/persona
- Updated to "Minimo 10 persone"

Also updated structured data for SEO purposes.

Closes #70

Generated with [Claude Code](https://claude.ai/code)