### PR TITLE
Fix homepage contact section: replace email with clickable link to form

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
                             <span class="contact-icon">📧</span>
                             <div>
                                 <h5>Email</h5>
-                                <p>ai@niuexa.ai</p>
+                                <p><a href="contatti.html#form-column">Compila il form <span style="text-decoration: underline;">qui</span></a></p>
                             </div>
                         </div>
                         <div class="contact-item">


### PR DESCRIPTION
**Summary**
- Replace 'Email ai@niuexa.ai' with 'Compila il form qui' in homepage contact section
- Link 'qui' to contact form section (contatti.html#form-column)
- Maintains underline styling for clickable text

**Reference**
Closes #72

Generated with [Claude Code](https://claude.ai/code)