### PR TITLE
Remove special offer bundle and update FAQ question in training page

### DIFF
--- a/training.html
+++ b/training.html
@@ -179,7 +179,7 @@
             },
             {
                 "@type": "Question",
-                "name": "I corsi AI sono riconosciuti ufficialmente?",
+                "name": "Viene rilasciato un attestato di frequenza?",
                 "acceptedAnswer": {
                     "@type": "Answer",
                     "text": "Sì, tutti i nostri corsi rilasciano attestati di frequenza indispensabili per la crescita continua delle competenze nel settore AI."
@@ -629,35 +629,6 @@
                     </article>
                 </div>
                 
-                <!-- Bundle Offer -->
-                <div class="bundle-offer">
-                    <div class="bundle-header">
-                        <h3>🎁 Offerta Speciale: Percorso Completo AI</h3>
-                        <div class="bundle-badge">Risparmia €1,000</div>
-                    </div>
-                    <div class="bundle-content">
-                        <div class="bundle-description">
-                            <p><strong>Tutti e 3 i corsi a un prezzo speciale.</strong> Ideale per team che vogliono acquisire competenze AI complete.</p>
-                            <ul>
-                                <li>✅ Fondamenti di AI Generativa</li>
-                                <li>✅ Mastery del Prompt Engineering</li>
-                                <li>✅ Sviluppo Agenti AI Enterprise</li>
-                                <li>✅ Mentorship 1-on-1 per 3 mesi</li>
-                                <li>✅ Accesso community esclusiva</li>
-                            </ul>
-                        </div>
-                        <div class="bundle-pricing">
-                            <div class="bundle-price">
-                                <span class="price-original">€5,500</span>
-                                <span class="price-current">€4,500</span>
-                                <span class="price-save">Risparmia €1,000</span>
-                            </div>
-                            <a href="#contact-training" class="btn btn-primary btn-large">
-                                Prenota Percorso Completo
-                            </a>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
 
@@ -758,7 +729,7 @@
                     <div class="faq-item">
                         <h3 class="faq-question">
                             <button class="faq-toggle" onclick="toggleFAQ(this)">
-                                I corsi sono riconosciuti ufficialmente?
+                                Viene rilasciato un attestato di frequenza?
                                 <span class="faq-icon">+</span>
                             </button>
                         </h3>


### PR DESCRIPTION
Fixes #81

This PR implements the requested modifications to the training page:

- ✅ Removed the "Offerta Speciale: Percorso Completo AI" bundle section
- ✅ Updated FAQ question from "I corsi sono riconosciuti ufficialmente?" to "Viene rilasciato un attestato di frequenza?"
- ✅ Updated corresponding structured data schema

Generated with [Claude Code](https://claude.ai/code)