### PR TITLE
Uniforma il design delle card dei corsi di formazione

### DIFF
--- a/training.css
+++ b/training.css
@@ -216,16 +216,7 @@
     overflow: hidden;
 }
 
-.program-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.15);
-}
-
-.program-card.featured {
-    position: relative;
-}
-
-.program-card.featured::before {
+.program-card::before {
     content: '';
     position: absolute;
     top: 0;
@@ -235,8 +226,9 @@
     background: var(--gradient-primary);
 }
 
-.program-card.premium {
-    position: relative;
+.program-card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.15);
 }
 
 .program-header {
@@ -285,13 +277,9 @@
     letter-spacing: 0.5px;
 }
 
-.program-badge.popular {
-    background: var(--primary-blue);
-    color: white;
-}
-
+.program-badge.popular,
 .program-badge.premium {
-    background: var(--primary-green);
+    background: var(--primary-blue);
     color: white;
 }
 


### PR DESCRIPTION
Questo PR risolve l'issue #83 uniformando il design visivo delle card dei corsi di formazione.

## Modifiche
- Applicato bordo gradient superiore (4px) a tutte le card dei corsi
- Standardizzato il colore dei badge (tutti in blu primario)
- Rimosso le differenze visive tra card featured, standard e premium
- Mantenuto il contenuto specifico di ogni corso invariato

## Risultato
Ora quando un utente clicca su "Dettagli completi" per qualsiasi dei tre corsi, l'aspetto visivo è identico e professionale.

Generated with [Claude Code](https://claude.ai/code)