### PR TITLE
feat: expand CTA block to full width under both contact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,20 +755,6 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <!-- Innovation CTA Moved to Left Column -->
-                    <div class="innovation-cta-standalone">
-                        <div class="cta-content">
-                            <h5>Vuoi Questa Tecnologia per la Tua Azienda?</h5>
-                            <p>
-                                Questa segretaria AI è solo un esempio di quello che possiamo creare per te. 
-                                Immagina di automatizzare completamente la gestione dei contatti della tua azienda!
-                            </p>
-                            <a href="products.html" class="btn btn-secondary">
-                                Scopri i Nostri Agenti AI
-                            </a>
-                        </div>
-                    </div>
                 </div>
                 
                 <div class="traditional-contact-info">
@@ -803,6 +789,20 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+            
+            <!-- Innovation CTA Spanning Full Width -->
+            <div class="innovation-cta-standalone">
+                <div class="cta-content">
+                    <h5>Vuoi Questa Tecnologia per la Tua Azienda?</h5>
+                    <p>
+                        Questa segretaria AI è solo un esempio di quello che possiamo creare per te. 
+                        Immagina di automatizzare completamente la gestione dei contatti della tua azienda!
+                    </p>
+                    <a href="products.html" class="btn btn-secondary">
+                        Scopri i Nostri Agenti AI
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Expands the "Vuoi Questa Tecnologia per la Tua Azienda?" CTA block to span the full width under both "Segretaria AI Attiva" and "Preferisci i Metodi Tradizionali?" boxes.

## Changes:
- Moved innovation CTA outside the grid container
- CTA now spans full width under both contact sections
- Maintains responsive behavior with existing CSS

Closes issue request from PR #88

🤖 Generated with [Claude Code](https://claude.ai/code)