### PR TITLE
fix: remove office descriptions and update experience text

### DIFF
--- a/chi-siamo.html
+++ b/chi-siamo.html
@@ -370,14 +370,12 @@
                     <img src="img/ufficibebitmilano.jpg" alt="Ufficio Niuexa Milano" style="width: 100%; height: 300px; object-fit: cover;">
                     <div class="office-info" style="padding: 30px;">
                         <h3 style="font-family: var(--font-primary); color: var(--primary-blue); margin-bottom: 10px;">Milano</h3>
-                        <p style="color: var(--medium-gray);">Il nostro hub principale per l'innovazione AI e la trasformazione digitale delle aziende.</p>
                     </div>
                 </div>
                 <div class="office-card" style="background: white; border-radius: 20px; overflow: hidden; box-shadow: 0 10px 40px rgba(0,0,0,0.1);">
                     <img src="img/ufficiotorino.jpg" alt="Ufficio Niuexa Torino" style="width: 100%; height: 300px; object-fit: cover;">
                     <div class="office-info" style="padding: 30px;">
                         <h3 style="font-family: var(--font-primary); color: var(--primary-blue); margin-bottom: 10px;">Torino</h3>
-                        <p style="color: var(--medium-gray);">Centro di eccellenza per lo sviluppo di soluzioni AI personalizzate e consulenza strategica.</p>
                     </div>
                 </div>
             </div>

--- a/contatti.html
+++ b/contatti.html
@@ -226,7 +226,7 @@
                                 <div class="info-icon">✅</div>
                                 <div>
                                     <h4>Esperienza Comprovata</h4>
-                                    <p>Oltre 10 anni di esperienza nell'AI e automazione</p>
+                                    <p>Oltre 5 anni di esperienza nell'AI e automazione</p>
                                 </div>
                             </div>
                             <div class="info-item">
@@ -259,14 +259,12 @@
                             <img src="img/ufficibebitmilano.jpg" alt="Ufficio Niuexa Milano" class="office-image">
                             <div class="office-info">
                                 <h4>Milano</h4>
-                                <p>Hub principale per l'innovazione AI</p>
                             </div>
                         </div>
                         <div class="office-card">
                             <img src="img/ufficiotorino.jpg" alt="Ufficio Niuexa Torino" class="office-image">
                             <div class="office-info">
                                 <h4>Torino</h4>
-                                <p>Centro di eccellenza per soluzioni AI</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This PR addresses issue #90 by making the following text modifications:

**Chi Siamo page changes:**
- Removed descriptive text from Milano office box
- Removed descriptive text from Torino office box

**Contatti page changes:**
- Removed "Hub principale per l'innovazione AI" from Milano office
- Removed office description from Torino office
- Updated experience text from "Oltre 10 anni" to "Oltre 5 anni"

Closes #90

Generated with [Claude Code](https://claude.ai/code)