### PR TITLE
Fix: Update button links in Eventi page CTA section

### DIFF
--- a/eventi.html
+++ b/eventi.html
@@ -173,9 +173,9 @@
                 <h2>Unisciti alla Community AI di Milano</h2>
                 <p style="color: white !important; opacity: 1 !important;">Non perdere l'occasione di far parte della community AI più attiva di Milano. Ogni evento è un'opportunità per imparare, crescere e costruire relazioni significative. Connettiti con noi anche sul Discord per discussioni continue e aggiornamenti esclusivi!</p>
                 <div class="cta-buttons">
-                    <a href="https://www.eventbrite.it/o/niuexa-eventi-ai" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Registrati su Eventbrite</a>
+                    <a href="https://www.eventbrite.com/o/niuexa-117562177741?" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Registrati su Eventbrite</a>
                     <a href="https://discord.gg/vyKckeS3" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Unisciti al Discord</a>
-                    <a href="mailto:eventi@niuexa.com" class="btn btn-outline">Contattaci</a>
+                    <a href="mailto:ai@niuexa.ai" class="btn btn-outline">Contattaci</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Update button links in the "Unisciti alla Community AI di Milano" section of the Eventi page:

- Changed 'Registrati su Eventbrite' button to point to https://www.eventbrite.com/o/niuexa-117562177741?
- Updated 'Contattaci' button to use mailto:ai@niuexa.ai

Requested by @stefania-pidone-niuexa in PR #94

Generated with [Claude Code](https://claude.ai/code)