### PR TITLE
Update AI products pricing and formatting

### DIFF
--- a/products.html
+++ b/products.html
@@ -407,12 +407,14 @@
                     
                     <div class="product-pricing-detailed" style="background: #f8f9fa; padding: 1.5rem; border-radius: 16px; margin-bottom: 2rem;">
                         <div class="pricing-main" style="text-align: center; margin-bottom: 1rem;">
-                            <span style="font-size: 2.2rem; font-weight: 700; color: #0066cc;">€2,500</span>
-                            <span style="color: #6c757d; font-size: 1rem;">/mese</span>
+                            <span style="color: #6c757d; font-size: 1rem;">A partire da </span>
+                            <span style="font-size: 2.2rem; font-weight: 700; color: #0066cc;">€1.000</span>
+                            <span style="color: #6c757d; font-size: 1rem;"> /mese</span>
                         </div>
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
                             <div>Setup e configurazione: €5,000</div>
                             <div>Training personalizzato: €2,000</div>
+                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #0066cc;">ROI atteso entro 12 mesi*</div>
                         </div>
                     </div>
@@ -475,12 +477,14 @@
                     
                     <div class="product-pricing-detailed" style="background: #f8f9fa; padding: 1.5rem; border-radius: 16px; margin-bottom: 2rem;">
                         <div class="pricing-main" style="text-align: center; margin-bottom: 1rem;">
-                            <span style="font-size: 2.2rem; font-weight: 700; color: #00cc66;">€3,000</span>
-                            <span style="color: #6c757d; font-size: 1rem;">/mese</span>
+                            <span style="color: #6c757d; font-size: 1rem;">A partire da </span>
+                            <span style="font-size: 2.2rem; font-weight: 700; color: #00cc66;">€1.250</span>
+                            <span style="color: #6c757d; font-size: 1rem;"> /mese</span>
                         </div>
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
                             <div>Setup e integrazione CRM: €6,000</div>
-                            <div>Training team vendite: €3,000</div>
+                            <div>Training team vendite: €2,000</div>
+                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #00cc66;">Diminuzione costi</div>
                         </div>
                     </div>
@@ -547,12 +551,14 @@
                     
                     <div class="product-pricing-detailed" style="background: #f8f9fa; padding: 1.5rem; border-radius: 16px; margin-bottom: 2rem;">
                         <div class="pricing-main" style="text-align: center; margin-bottom: 1rem;">
-                            <span style="font-size: 2.2rem; font-weight: 700; color: #9b59b6;">A partire da 1.250 euro</span>
-                            <span style="color: #6c757d; font-size: 1rem;">/mese</span>
+                            <span style="color: #6c757d; font-size: 1rem;">A partire da </span>
+                            <span style="font-size: 2.2rem; font-weight: 700; color: #9b59b6;">1.250</span>
+                            <span style="color: #6c757d; font-size: 1rem;"> euro/mese</span>
                         </div>
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
-                            <div>Setup e integrazione telefonica: €8,000</div>
-                            <div>Training voci personalizzate: €4,000</div>
+                            <div>Setup e integrazione telefonica: €6,000</div>
+                            <div>Training voci personalizzate: €2,000</div>
+                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #9b59b6;">Soddisfazione clienti >90%</div>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #96

Updated pricing and costs for all three AI products:

- **Agente Vocale AI**: Updated pricing format, reduced setup and training costs, added monthly fee
- **Agente Marketing AI**: Changed price to starting from €1,000, added monthly fee
- **Agente Vendite AI**: Changed price to starting from €1,250, reduced training cost, added monthly fee

All products now have consistent formatting with "A partire da" and "/mese" in same size and price amount highlighted larger.

Generated with [Claude Code](https://claude.ai/code)