### PR TITLE
Fix AI products pricing formatting

### DIFF
--- a/products.html
+++ b/products.html
@@ -414,7 +414,7 @@
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
                             <div>Setup e configurazione: €5,000</div>
                             <div>Training personalizzato: €2,000</div>
-                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
+                            <div>Canone Mensile: €1.000 /mese (include<br>aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #0066cc;">ROI atteso entro 12 mesi*</div>
                         </div>
                     </div>
@@ -484,7 +484,7 @@
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
                             <div>Setup e integrazione CRM: €6,000</div>
                             <div>Training team vendite: €2,000</div>
-                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
+                            <div>Canone Mensile: €1.000 /mese (include<br>aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #00cc66;">Diminuzione costi</div>
                         </div>
                     </div>
@@ -552,13 +552,13 @@
                     <div class="product-pricing-detailed" style="background: #f8f9fa; padding: 1.5rem; border-radius: 16px; margin-bottom: 2rem;">
                         <div class="pricing-main" style="text-align: center; margin-bottom: 1rem;">
                             <span style="color: #6c757d; font-size: 1rem;">A partire da </span>
-                            <span style="font-size: 2.2rem; font-weight: 700; color: #9b59b6;">1.250</span>
-                            <span style="color: #6c757d; font-size: 1rem;"> euro/mese</span>
+                            <span style="font-size: 2.2rem; font-weight: 700; color: #9b59b6;">€1.250</span>
+                            <span style="color: #6c757d; font-size: 1rem;"> /mese</span>
                         </div>
                         <div class="pricing-details" style="font-size: 0.9rem; color: #6c757d; text-align: center;">
                             <div>Setup e integrazione telefonica: €6,000</div>
                             <div>Training voci personalizzate: €2,000</div>
-                            <div>Canone Mensile: €1.000 /mese (include aggiornamenti e assistenza)</div>
+                            <div>Canone Mensile: €1.000 /mese (include<br>aggiornamenti e assistenza)</div>
                             <div style="margin-top: 0.5rem; font-weight: 600; color: #9b59b6;">Soddisfazione clienti >90%</div>
                         </div>
                     </div>


### PR DESCRIPTION
Follow-up to PR #97 to address formatting issues:

- Add line breaks before 'aggiornamenti e assistenza' in all 3 products' Canone Mensile text
- Fix Agente Vocale AI pricing format from '1.250 euro/mese' to '€1.250 /mese' to match other products

Generated with [Claude Code](https://claude.ai/code)