### PR TITLE
Replace ElevenLabs widget agent ID across all pages

### DIFF
--- a/ai-readiness-tool.html
+++ b/ai-readiness-tool.html
@@ -969,7 +969,7 @@
     </style>
 
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/chi-siamo.html
+++ b/chi-siamo.html
@@ -498,7 +498,7 @@
     <script src="cookie-banner.js"></script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/consulting.html
+++ b/consulting.html
@@ -447,7 +447,7 @@
     <script src="includes/includes.js"></script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/contatti.html
+++ b/contatti.html
@@ -350,7 +350,7 @@
     <script src="cookie-banner.js"></script>
 
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -818,7 +818,7 @@
     <script src="cookie-banner.js"></script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/landing-marketing-agent.html
+++ b/landing-marketing-agent.html
@@ -421,7 +421,7 @@
     </script>
 
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
     
     <!-- Performance and Analytics -->

--- a/landing-sales-agent.html
+++ b/landing-sales-agent.html
@@ -420,7 +420,7 @@
     </script>
 
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
     
     <!-- Performance and Analytics -->

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -420,7 +420,7 @@
     </script>
 
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
     
     <!-- Performance and Analytics -->

--- a/login.html
+++ b/login.html
@@ -314,7 +314,7 @@
     </script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -1003,7 +1003,7 @@
     </script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/roi-calculator.html
+++ b/roi-calculator.html
@@ -401,7 +401,7 @@
     <script src="includes/includes.js"></script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>

--- a/training.html
+++ b/training.html
@@ -895,7 +895,7 @@
     </script>
     
     <!-- ElevenLabs ConvAI Widget -->
-    <elevenlabs-convai agent-id="Pu3ZJiznUQO0GRQU3PGT"></elevenlabs-convai>
+    <elevenlabs-convai agent-id="agent_7101k6bmr19tf5d9jgx90ysjr75f"></elevenlabs-convai>
     <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
Updated agent-id from 'Pu3ZJiznUQO0GRQU3PGT' to 'agent_7101k6bmr19tf5d9jgx90ysjr75f' across 12 HTML pages, including the home page (index.html) that was previously missed.

Fixes #113

🤖 Generated with [Claude Code](https://claude.ai/code)