### PR TITLE
Fix pricing boxes styling and content updates

### DIFF
--- a/ai-readiness-tool.html
+++ b/ai-readiness-tool.html
@@ -566,7 +566,7 @@
                         </ul>
                     </div>
                     
-                    <a href="#contact" class="btn btn-secondary" style="width: 100%; padding: 1rem;">Contattaci</a>
+                    <a href="#contact" class="btn btn-secondary" style="width: 100%; padding: 1rem; border-radius: 8px;">Contattaci</a>
                 </div>
 
                 <!-- Pro Plan -->
@@ -592,15 +592,15 @@
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Analisi mensile</strong> di pagine chiave e Home.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Piano d'azione strategico</strong> personalizzato con priorità in base all'impatto.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Video Call di 1 ora</strong> per onboarding e spiegazione dettagliata di risultati e suggerimenti.
                                 </li>
                             </ul>
@@ -613,15 +613,15 @@
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Supporto email</strong> e assistenza tecnica per tutto il periodo di servizio.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Report mensile</strong> completo con tracking dei progressi e metriche raggiunte.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
                                     <strong>Analisi benchmark competitor</strong> (Top 3) trimestrale via email.
                                 </li>
                             </ul>
@@ -629,21 +629,17 @@
                         
                         
                         <h5 style="font-size: 1rem; color: white; margin: 1.5rem 0 0.5rem; font-weight: 600;">Perfetto per chi:</h5>
-                        <ul style="list-style: none; padding: 0; margin-bottom: 1rem;">
-                            <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
+                        <ul style="list-style: disc; padding-left: 1.2rem; margin-bottom: 1rem; color: white; font-size: 0.9rem;">
+                            <li style="margin-bottom: 0.3rem;">
                                 Ha un <strong>team di sviluppo/marketing</strong> interno (hai le risorse, ti serve la strategia).
                             </li>
-                            <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 È <strong>proattivo</strong> e attento al trend AI (non vuole restare indietro).
                             </li>
-                            <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 Vuole <strong>expertise di alto livello</strong> senza l'assunzione di un esperto interno.
                             </li>
-                            <li style="padding: 0.3rem 0; color: white; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 Ha la capacità di implementare ma <strong>non sa COSA fare</strong>.
                             </li>
                         </ul>
@@ -666,7 +662,7 @@
                     </div>
                     
                     <div class="program-actions" style="display: flex; gap: 1rem; margin-bottom: 1rem;">
-                        <a href="#contact" class="btn" style="flex: 1; padding: 1rem; background: white; color: #0066cc; font-weight: 600; text-decoration: none; display: inline-block; text-align: center; border-radius: 8px;">Inizia Ora</a>
+                        <a href="#contact" class="btn" style="flex: 1; padding: 1rem; background: white; color: #0066cc; font-weight: 600; text-decoration: none; display: inline-block; text-align: center; border-radius: 8px;">Contattaci</a>
                         <button class="btn btn-secondary" onclick="toggleProgramDetails(this)" style="flex: 1; padding: 1rem; background: rgba(255, 255, 255, 0.2); color: white; border: 2px solid white; font-weight: 600; border-radius: 8px; cursor: pointer;">
                             Dettagli
                         </button>
@@ -716,7 +712,7 @@
                     <h3 style="font-size: 1.5rem; margin-bottom: 0.5rem; color: #2c3e50;">Business</h3>
                     <p style="color: #6c757d; margin-bottom: 2rem;">Per aziende e agenzie</p>
                     <div class="price" style="margin-bottom: 1rem;">
-                        <span style="font-size: 1rem; font-weight: 700; color: #0066cc;">A partire da </span>
+                        <span style="font-size: 1rem; font-weight: 700; color: #6c757d;">A partire da </span>
                         <span style="font-size: 3rem; font-weight: 700; color: #0066cc;">€2.000</span>
                         <span style="color: #6c757d; font-size: 1rem;">/mese</span>
                     </div>
@@ -802,30 +798,25 @@
                         </div>
                         
                         <h5 style="font-size: 1rem; color: #2c3e50; margin: 1.5rem 0 0.5rem; font-weight: 600;">Perfetto per chi:</h5>
-                        <ul style="list-style: none; padding: 0; margin-bottom: 1rem;">
-                            <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
+                        <ul style="list-style: disc; padding-left: 1.2rem; margin-bottom: 1rem; color: #6c757d; font-size: 0.9rem;">
+                            <li style="margin-bottom: 0.3rem;">
                                 <strong>C-Level / Executive</strong>: Vuole risultati di alto livello senza coinvolgimento operativo.
                             </li>
-                            <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 <strong>Aziende senza team tecnico</strong>: Non hai sviluppatori o content creator interni.
                             </li>
-                            <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 <strong>Vuole la massima velocità</strong>: Implementazione professionale e rapida.
                             </li>
-                            <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 <strong>Siti Enterprise/Complessi</strong>: E-commerce, SaaS o portali con oltre 50 pagine.
                             </li>
-                            <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
+                            <li style="margin-bottom: 0.3rem;">
                                 <strong>Richiede Outsourcing Completo AEO</strong>: Vuoi concentrarti sul core business, noi pensiamo all'AI.
                             </li>
                         </ul>
                         
-                        <h5 style="font-size: 1rem; color: #ff6b6b; margin: 1.5rem 0 0.5rem; font-weight: 600;">NON adatto per chi:</h5>
+                        <h5 style="font-size: 1rem; color: #2c3e50; margin: 1.5rem 0 0.5rem; font-weight: 600;">NON adatto per chi:</h5>
                         <ul style="list-style: none; padding: 0; margin-bottom: 1.5rem;">
                             <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
                                 <span style="position: absolute; left: 0; color: #ff6b6b; font-size: 1rem;">❌</span>
@@ -843,7 +834,7 @@
                     </div>
                     
                     <div class="program-actions" style="display: flex; gap: 1rem;">
-                        <a href="#contact" class="btn btn-primary" style="flex: 1; padding: 1rem; background: #0066cc; color: white; text-decoration: none; display: inline-block; text-align: center; border-radius: 8px; font-weight: 600;">Inizia Ora</a>
+                        <a href="#contact" class="btn btn-primary" style="flex: 1; padding: 1rem; background: #0066cc; color: white; text-decoration: none; display: inline-block; text-align: center; border-radius: 8px; font-weight: 600;">Contattaci</a>
                         <button class="btn btn-secondary" onclick="toggleProgramDetails(this)" style="flex: 1; padding: 1rem; background: transparent; color: #0066cc; border: 2px solid #0066cc; font-weight: 600; border-radius: 8px; cursor: pointer;">
                             Dettagli
                         </button>


### PR DESCRIPTION
Implemented styling improvements and content updates to pricing boxes:

- Replace ✅ icons with ✓ throughout document
- Convert "Perfetto per chi" lists from icons to bullet points in Pro and Business boxes 
- Replace "Inizia Ora" buttons with "Contattaci"
- Fix Business box color styling: "A partire da" now matches "/mese" color
- Fix Business box "NON adatto per chi" header color to match "Perfetto per chi"
- Standardize button border-radius to 8px across all pricing boxes

Reference to original PR #137

🤖 Generated with [Claude Code](https://claude.ai/code)