### PR TITLE
Update pricing boxes: replace numbered lists with ✅ icons and fix styling

### DIFF
--- a/ai-readiness-tool.html
+++ b/ai-readiness-tool.html
@@ -583,11 +583,11 @@
                     </p>
                     
                     <div class="pro-plan-content" style="text-align: left; margin-bottom: 2rem;">
-                        <h4 style="font-size: 1.1rem; color: white; margin-bottom: 1rem; font-weight: 600;">Cosa Include:</h4>
+                        <h4 style="font-size: 1.1rem; color: white; margin-bottom: 1rem; font-weight: 600;">Cosa include:</h4>
                         
                         <div class="accordion-section">
                             <h5 class="accordion-header" onclick="toggleAccordionSection(this)" style="font-size: 1rem; color: white; margin: 1.5rem 0 0.5rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: space-between;">
-                                1. Analisi e Strategia
+                                ✅ Analisi e Strategia
                                 <span class="accordion-icon" style="font-size: 0.8rem; transition: transform 0.3s ease;">▼</span>
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
@@ -608,7 +608,7 @@
                         
                         <div class="accordion-section">
                             <h5 class="accordion-header" onclick="toggleAccordionSection(this)" style="font-size: 1rem; color: white; margin: 1.5rem 0 0.5rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: space-between;">
-                                2. Supporto Continuo
+                                ✅ Supporto Continuo
                                 <span class="accordion-icon" style="font-size: 0.8rem; transition: transform 0.3s ease;">▼</span>
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
@@ -721,24 +721,24 @@
                     </p>
                     
                     <div style="text-align: left; margin-bottom: 2rem;">
-                        <h4 style="font-size: 1.1rem; color: #2c3e50; margin-bottom: 1rem; font-weight: 600;">Cosa Include</h4>
+                        <h4 style="font-size: 1.1rem; color: #2c3e50; margin-bottom: 1rem; font-weight: 600;">Cosa include:</h4>
                         
                         <div class="accordion-section">
                             <h5 class="accordion-header" onclick="toggleAccordionSection(this)" style="font-size: 1rem; color: #2c3e50; margin: 1.5rem 0 0.5rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: space-between;">
-                                1. Analisi Completa
+                                ✅ Analisi Completa
                                 <span class="accordion-icon" style="font-size: 0.8rem; transition: transform 0.3s ease;">▼</span>
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Analisi mensile del sito</strong>: Monitoraggio approfondito delle 10-20 pagine più importanti.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Video Call 2 ore/mese</strong>: Sessioni strategiche per l'analisi dei risultati e l'orientamento futuro.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Supporto prioritario</strong>: Risposta via mail garantita entro 4 ore lavorative.
                                 </li>
                             </ul>
@@ -746,26 +746,26 @@
                         
                         <div class="accordion-section">
                             <h5 class="accordion-header" onclick="toggleAccordionSection(this)" style="font-size: 1rem; color: #2c3e50; margin: 1.5rem 0 0.5rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: space-between;">
-                                2. Implementazione Completa
+                                ✅Implementazione Completa
                                 <span class="accordion-icon" style="font-size: 0.8rem; transition: transform 0.3s ease;">▼</span>
                             </h5>
                             <div class="accordion-content" style="display: none;">
                                 <p style="font-size: 0.85rem; color: #6c757d; margin-bottom: 0.5rem; font-style: italic;">(Niuexa si occupa di tutto il progetto)</p>
                                 <ul style="list-style: none; padding: 0; margin-bottom: 1rem;">
                                     <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                         <strong>Fix Tecnici Completi</strong>: Implementazione di robots.txt, ottimizzazione velocità e accessibilità, etc.
                                     </li>
                                     <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                         <strong>Creazione Contenuti AI</strong>: Scrittura di contenuti ottimizzati per AEO (AI Engine Optimization).
                                     </li>
                                     <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                         <strong>Modifiche Dirette al Sito</strong>: Interventi su HTML, CSS e configurazioni (previa approvazione).
                                     </li>
                                     <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                        <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                         <strong>Gestione File AI</strong>: Creazione e manutenzione di llms.txt e altri file specifici per l'AI.
                                     </li>
                                 </ul>
@@ -774,24 +774,24 @@
                         
                         <div class="accordion-section">
                             <h5 class="accordion-header" onclick="toggleAccordionSection(this)" style="font-size: 1rem; color: #2c3e50; margin: 1.5rem 0 0.5rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: space-between;">
-                                3. Tracking e Reporting Avanzato
+                                ✅Tracking e Reporting Avanzato
                                 <span class="accordion-icon" style="font-size: 0.8rem; transition: transform 0.3s ease;">▼</span>
                             </h5>
                             <ul class="accordion-content" style="list-style: none; padding: 0; margin-bottom: 1rem; display: none;">
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Report mensile</strong>: Dettagli sui progressi e metriche raggiunte.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Benchmark competitor</strong>: Analisi mensile su 3 competitor chiave.
                                 </li>
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Citation tracking</strong>: Monitoraggio delle citazioni del brand da parte di AI (ChatGPT, Perplexity, etc.).
                                 </li>
                                 <li style="padding: 0.3rem 0; color: #6c757d; position: relative; padding-left: 1.8rem; font-size: 0.9rem;">
-                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✅</span>
+                                    <span style="position: absolute; left: 0; color: #00cc66; font-size: 1rem;">✓</span>
                                     <strong>Quarterly Business Review (QBR)</strong>: Revisione trimestrale completa con analisi ROI.
                                 </li>
                             </ul>


### PR DESCRIPTION
Implemented requested pricing box updates:

- Replace numbered lists with ✅ icons in Pro and Business boxes
- Add colons after "Cosa include" sections
- Replace ✅ with ✓ in Business box accordion expansions

Reference to original PR #138

🤖 Generated with [Claude Code](https://claude.ai/code)