### PR TITLE
Fix font sizes in Pro plan sections to be 16px

### DIFF
--- a/ai-readiness-tool.html
+++ b/ai-readiness-tool.html
@@ -1250,12 +1250,12 @@
 
         /* Pro plan content styling for better fit */
         .pro-plan-content ul li {
-            font-size: 0.85rem !important;
+            font-size: 1rem !important;
             line-height: 1.3 !important;
         }
 
         .pro-plan-content ul li strong {
-            font-size: 0.85rem !important;
+            font-size: 1rem !important;
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
Updated CSS rules for .pro-plan-content sections to use font-size: 1rem (16px) instead of 0.85rem. This affects the bullet point text in 'Analisi e Strategia', 'Supporto Continuo', and 'Perfetto per chi' sections as highlighted in user feedback.

Generated with [Claude Code](https://claude.ai/code)