### PR TITLE
Remove pricing box from AI-Readiness section on Products page

### DIFF
--- a/products.html
+++ b/products.html
@@ -882,17 +882,9 @@
                     </div>
                 </div>
                 <div style="text-align: center;">
-                    <div style="background: white; border-radius: 20px; padding: 2rem; box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);">
-                        <p style="color: #6c757d; font-size: 0.9rem; margin-bottom: 0.5rem;">A partire da</p>
-                        <div style="font-size: 2.5rem; font-weight: 700; color: #0066cc; margin-bottom: 0.5rem;">€500</div>
-                        <p style="color: #6c757d; font-size: 0.9rem; margin-bottom: 1.5rem;">Garanzia soddisfatti<br>o rimborsati</p>
-                        <a href="ai-readiness-tool.html" class="btn btn-primary" style="padding: 1rem 2rem; font-size: 1rem; display: inline-block; margin-bottom: 0.5rem;">
-                            Scopri di Più →
-                        </a>
-                        <div style="font-size: 0.85rem; color: #00cc66; font-weight: 600;">
-                            ✓ Analisi Gratuita Disponibile
-                        </div>
-                    </div>
+                    <a href="ai-readiness-tool.html" class="btn btn-primary" style="padding: 1rem 2rem; font-size: 1rem; display: inline-block;">
+                        Scopri di Più →
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Remove entire pricing box container with €500 price, guarantee text, and "Analisi Gratuita Disponibile" text. Keep only the "Scopri di Più" button as requested. Maintain mobile responsiveness with existing flex-wrap layout.

Fixes #153

Generated with [Claude Code](https://claude.ai/code)