### PR TITLE
Fix mobile dropdown menu for Soluzioni and Risorse

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2742,6 +2742,7 @@ button[aria-busy="true"]::after {
         visibility: visible;
         max-height: 200px;
         margin-bottom: 1rem;
+        transform: none;
     }
 
     .dropdown-arrow {


### PR DESCRIPTION
Fixed mobile dropdown menu issue where "Soluzioni" and "Risorse" dropdowns were not opening on mobile devices.

## Changes
- Added `transform: none;` to mobile dropdown CSS to override desktop transform property
- Fixes CSS specificity conflict between desktop and mobile styles

Closes #155

Generated with [Claude Code](https://claude.ai/code)