### PR TITLE
Fix mobile dropdown CSS transform conflict

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2734,6 +2734,7 @@ button[aria-busy="true"]::after {
         visibility: hidden;
         max-height: 0;
         overflow: hidden;
+        transform: none !important;
         transition: all 0.3s ease;
     }
 


### PR DESCRIPTION
Fixed mobile dropdown menu issue where "Soluzioni" and "Risorse" dropdowns were not opening on mobile devices.

## Changes
- Added `transform: none !important;` to mobile dropdown CSS to override desktop transform property
- Fixes CSS specificity conflict between desktop and mobile styles

Generated with [Claude Code](https://claude.ai/code)