### PR TITLE
fix: white text color for CTA section title on landing page

### DIFF
--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -212,7 +212,7 @@
             <div class="hero-gradient"></div>
         </div>
         <div class="container" style="text-align: center; padding: 80px 0; position: relative; z-index: 2;">
-            <h2 class="section-title" style="color: white; margin-bottom: 1.5rem; font-size: 2.5rem;">Pronto a Trasformare la Tua Azienda?</h2>
+            <h2 class="section-title" style="margin-bottom: 1.5rem; font-size: 2.5rem;">Pronto a Trasformare la Tua Azienda?</h2>
             <p style="color: rgba(255,255,255,0.9); font-size: 1.2rem; margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto;">
                 Contattaci oggi per una consulenza gratuita e scopri come l'AI può rivoluzionare il tuo business
             </p>

--- a/styles.css
+++ b/styles.css
@@ -4195,6 +4195,14 @@ html {
     color: var(--primary-blue);
 }
 
+.cta-section .section-title {
+    color: var(--white) !important;
+    background: none !important;
+    -webkit-background-clip: initial !important;
+    -webkit-text-fill-color: initial !important;
+    background-clip: initial !important;
+}
+
 /* Responsive Design for About Page */
 @media (max-width: 1024px) {
     .ceo-content {


### PR DESCRIPTION
Fixes #164

This PR addresses the poor readability of the "Pronto a Trasformare la Tua Azienda?" title in the Call to Action section of the landing page.

## Changes
- Added specific CSS rule for `.cta-section .section-title` to override gradient styling
- Removed redundant inline color style from HTML
- Ensures white text color (#FFFFFF) for proper contrast against dark background

## Technical Details
The issue was caused by the `.section-title` class having gradient text styling (`-webkit-text-fill-color: transparent`) which made the text unreadable against the dark CTA section background. The new CSS rule specifically targets titles within the CTA section to display as white text.

Generated with [Claude Code](https://claude.ai/code)