### PR TITLE
fix: resolve mobile dropdown menu issue for Soluzioni and Risorse sections

### DIFF
--- a/includes/includes.js
+++ b/includes/includes.js
@@ -236,9 +236,9 @@ function initNavigationFunctionality() {
         }
     });
 
-    // Close mobile menu when clicking on any link (including dropdown links)
-    const allNavLinks = document.querySelectorAll('.nav-link, .dropdown-link');
-    allNavLinks.forEach(link => {
+    // Close mobile menu when clicking on navigation links (but NOT dropdown toggles)
+    const navLinksOnly = document.querySelectorAll('.nav-link:not(.dropdown-toggle), .dropdown-link');
+    navLinksOnly.forEach(link => {
         link.addEventListener('click', function() {
             if (hamburger && navMenu) {
                 hamburger.classList.remove('active');


### PR DESCRIPTION
Fixes #168

This PR resolves the mobile menu issue where clicking on "Soluzioni" and "Risorse" dropdown toggles would close the mobile menu and redirect to homepage instead of opening the dropdown menus.

## Changes Made:
- Modified navigation event listener in `includes/includes.js` to exclude dropdown toggles from closing mobile menu
- Changed CSS selector from `.nav-link, .dropdown-link` to `.nav-link:not(.dropdown-toggle), .dropdown-link`
- This preserves dropdown functionality while maintaining proper mobile menu behavior

## Testing:
- Dropdown menus now open properly on mobile devices
- Mobile menu still closes when clicking on actual navigation links
- No inline styles were found or modified as requested

Generated with [Claude Code](https://claude.ai/code)