### PR TITLE
Fix landing page styling uniformity

### DIFF
--- a/landing-sales-agent.html
+++ b/landing-sales-agent.html
@@ -204,7 +204,7 @@
             </div>
 
             <!-- Key Features -->
-            <div class="features-detailed" style="background: linear-gradient(135deg, var(--primary-green), #009944); padding: 4rem 2rem; border-radius: 24px; color: white; text-align: center;">
+            <div class="features-detailed" style="background: linear-gradient(135deg, var(--primary-blue), var(--primary-green)); padding: 4rem 2rem; border-radius: 24px; color: white; text-align: center;">
                 <h3 style="font-size: 2rem; margin-bottom: 3rem; color: white;">Funzionalità Avanzate</h3>
                 <div class="features-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 2rem;">
                     <div class="feature-item">


### PR DESCRIPTION
Fix gradient styling for Funzionalità Avanzate section on sales-agent landing page

- Changed gradient from var(--primary-green), #009944 to var(--primary-blue), var(--primary-green)
- Now matches the styling used on voice-agent and marketing-agent landing pages
- Ensures consistent blue/green gradient across all three landing pages

Closes #181

🤖 Generated with [Claude Code](https://claude.ai/code)