### PR TITLE
Update Eventi page: change first event date and add second event

### DIFF
--- a/eventi.css
+++ b/eventi.css
@@ -91,9 +91,12 @@
 
 .events-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
     margin-top: 2rem;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .event-card {

--- a/eventi.js
+++ b/eventi.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {
                 id: 1,
                 title: "RENDI PIÙ EFFICIENTE LA TUA AZIENDA CON L'AI",
-                date: new Date('2025-11-13'),
+                date: new Date('2025-11-19'),
                 time: "18:00 - 20:00",
                 location: "Via Rutilia, 10 - 20141 Milano",
                 description: "Scopri come l'intelligenza artificiale può trasformare ogni aspetto della tua attività, dalla gestione dei dati alla comunicazione con i clienti. Impara a ottimizzare i processi aziendali e a raggiungere i tuoi obiettivi in modo più rapido e intelligente.",
@@ -17,6 +17,21 @@ document.addEventListener('DOMContentLoaded', function() {
                 topics: ["Efficienza Aziendale", "AI in Azienda", "Ottimizzazione Processi"],
                 speaker: "Roberto Botto e Gregor Maric",
                 registrationUrl: "https://www.eventbrite.com/e/rendi-piu-efficiente-la-tua-azienda-con-lai-tickets-1730433145119?aff=oddtdtcreator"
+            },
+            {
+                id: 2,
+                title: "RENDI PIÙ EFFICIENTE LA TUA AZIENDA CON L'AI",
+                date: new Date('2025-11-26'),
+                time: "18:00 - 20:00",
+                location: "Via Vittorio Andreis, 18/16/M - 10152 Torino",
+                description: "Scopri come l'intelligenza artificiale può trasformare ogni aspetto della tua attività, dalla gestione dei dati alla comunicazione con i clienti. Impara a ottimizzare i processi aziendali e a raggiungere i tuoi obiettivi in modo più rapido e intelligente.",
+                image: "img/eventi/event_team2.webp",
+                status: "available", // available, full, past
+                maxAttendees: 40,
+                currentAttendees: 0,
+                topics: ["Efficienza Aziendale", "AI in Azienda", "Ottimizzazione Processi"],
+                speaker: "Roberto Botto e Gregor Maric",
+                registrationUrl: "https://www.eventbrite.com/e/biglietti-rendi-piu-efficiente-la-tua-azienda-con-lai-1850864659019?aff=oddtdtcreator"
             }
         ],
         past: [


### PR DESCRIPTION
Updates the Eventi page per issue #185:

- Update first event date from Thursday 13 November to Wednesday 19 November 2025
- Add second event for Wednesday 26 November 2025 in Torino
- Change location for second event to Via Vittorio Andreis, 18/16/M - 10152 Torino
- Update registration link for second event to new Eventbrite URL
- Add appropriate event image for second event
- Improve CSS layout for side-by-side event display

Fixes #185

🤖 Generated with [Claude Code](https://claude.ai/code)