### PR TITLE
Fix Turin event image to remove Milan landmarks

### DIFF
--- a/eventi.js
+++ b/eventi.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 time: "18:00 - 20:00",
                 location: "Via Vittorio Andreis, 18/16/M - 10152 Torino",
                 description: "Scopri come l'intelligenza artificiale può trasformare ogni aspetto della tua attività, dalla gestione dei dati alla comunicazione con i clienti. Impara a ottimizzare i processi aziendali e a raggiungere i tuoi obiettivi in modo più rapido e intelligente.",
-                image: "img/eventi/event_team2.webp",
+                image: "img/eventi/event_team.webp",
                 status: "available", // available, full, past
                 maxAttendees: 40,
                 currentAttendees: 0,


### PR DESCRIPTION
Updates the image reference for the Turin event to use a more appropriate image without Milan's Duomo in the background.

Changes:
- Updated eventi.js line 28 to use `event_team.webp` instead of `event_team2.webp`
- Removes Milan landmarks from Turin event imagery

Related to merged PR #186

🤖 Generated with [Claude Code](https://claude.ai/code)