### PR TITLE
Fix event images: assign Milan landmarks to Milano event, Turin setting to Torino event

### DIFF
--- a/eventi.js
+++ b/eventi.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 time: "18:00 - 20:00",
                 location: "Via Rutilia, 10 - 20141 Milano",
                 description: "Scopri come l'intelligenza artificiale può trasformare ogni aspetto della tua attività, dalla gestione dei dati alla comunicazione con i clienti. Impara a ottimizzare i processi aziendali e a raggiungere i tuoi obiettivi in modo più rapido e intelligente.",
-                image: "img/eventi/event_placeholder.webp",
+                image: "img/eventi/event_team2.webp",
                 status: "available", // available, full, past
                 maxAttendees: 40,
                 currentAttendees: 0,


### PR DESCRIPTION
Updates event image assignments to ensure geographical consistency:

- Milano event now uses `event_team2.webp` (shows Milan's Duomo)
- Torino event keeps `event_team.webp` (generic business setting)
- Ensures proper matching between event locations and imagery

Generated with [Claude Code](https://claude.ai/code)