### PR TITLE
Remove setup and training pricing from landing page

### DIFF
--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -292,7 +292,6 @@
                 
                 <div class="pricing-header" style="text-align: center; margin-bottom: 2.5rem;">
                     <div class="price" style="font-size: 3rem; font-weight: 700; color: var(--primary-blue); font-family: var(--font-primary);"><span style="font-size: 1.2rem; color: var(--medium-gray);">A partire da </span>€1.250<span style="font-size: 1.2rem; color: var(--medium-gray);"> /mese</span></div>
-                    <p style="color: var(--medium-gray); margin-top: 0.5rem;">Setup e integrazione: €6,000 • Training: €2,000</p>
                 </div>
                 
                 <div class="pricing-features" style="margin-bottom: 2.5rem;">


### PR DESCRIPTION
Remove 'Setup e integrazione: €6,000 • Training: €2,000' text from the Soluzione Completa pricing section while preserving the monthly pricing display.

Fixes #217

Generated with [Claude Code](https://claude.ai/code)