### PR TITLE
fix: update landing page ROI text and remove ROI calculator button

### DIFF
--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -173,7 +173,7 @@
                         <span class="stat-label">Ore Risparmiate/Settimana</span>
                     </div>
                     <div class="stat-item">
-                        <span class="stat-number">100-150%</span>
+                        <span class="stat-number">100%</span>
                         <span class="stat-label">ROI</span>
                     </div>
                     <div class="stat-item">
@@ -183,7 +183,6 @@
                 </div>
                 <div class="hero-buttons">
                     <a href="#contact" class="btn-primary" style="padding: 15px 30px; margin: 10px;">Contattaci</a>
-                    <a href="roi-calculator.html" class="btn-secondary" style="padding: 15px 30px; margin: 10px;">Calcola il tuo ROI</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Implements changes requested in issue #219:

- Changed '100-150%' to '100%' in hero stats section
- Removed 'Calcola il tuo ROI' button from hero buttons

Resolves #219

Generated with [Claude Code](https://claude.ai/code)