### PR TITLE
Update Claude logo to official Claude AI SVG in partner sections

### DIFF
--- a/landing-aeo-geo-enterprise.html
+++ b/landing-aeo-geo-enterprise.html
@@ -228,7 +228,7 @@
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Automa</figcaption>
                 </figure>
                 <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/claude-logo.png" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
+                    <img src="https://upload.wikimedia.org/wikipedia/commons/8/8a/Claude_AI_logo.svg" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Claude</figcaption>
                 </figure>
             </div>

--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -244,7 +244,7 @@
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Automa</figcaption>
                 </figure>
                 <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/claude-logo.png" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
+                    <img src="https://upload.wikimedia.org/wikipedia/commons/8/8a/Claude_AI_logo.svg" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Claude</figcaption>
                 </figure>
             </div>

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -228,7 +228,7 @@
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Automa</figcaption>
                 </figure>
                 <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/claude-logo.png" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
+                    <img src="https://upload.wikimedia.org/wikipedia/commons/8/8a/Claude_AI_logo.svg" alt="Claude - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
                     <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Claude</figcaption>
                 </figure>
             </div>


### PR DESCRIPTION
Updates Claude logo in partner sections across all three landing pages

- Replace local Claude logo with official Claude AI SVG from Wikipedia
- Maintains consistent styling with other partner logos
- Updated landing-aeo-geo-enterprise.html, landing-voice-agent.html, landing-niuexa.html

Closes #234

🤖 Generated with [Claude Code](https://claude.ai/code)