### PR TITLE
Fix partner logo sizing and layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,10 @@
                     <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
+                <figure class="partner-logo">
+                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
+                    <figcaption>Automa</figcaption>
+                </figure>
             </div>
         </div>
     </section>

--- a/landing-aeo-geo-enterprise.html
+++ b/landing-aeo-geo-enterprise.html
@@ -187,46 +187,50 @@
     <section class="partners-section" style="padding: 80px 0; background: #f8f9fa;">
         <div class="container">
             <h2 class="section-title" style="text-align: center; margin-bottom: 4rem;">I Nostri Partner</h2>
-            <div class="partners-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem; align-items: center; justify-items: center;">
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Libera Group</figcaption>
+            <div class="partners-grid">
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" />
+                    <figcaption>Libera Group</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Microsoft</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" />
+                    <figcaption>Microsoft</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Bebit</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" />
+                    <figcaption>Bebit</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">OpenAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" />
+                    <figcaption>OpenAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google Gemini</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" />
+                    <figcaption>Google Gemini</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Anthropic</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" />
+                    <figcaption>Anthropic</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">CrewAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" />
+                    <figcaption>CrewAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">ElevenLabs</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" />
+                    <figcaption>ElevenLabs</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" />
+                    <figcaption>Google</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">LangChain</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
+                    <figcaption>LangChain</figcaption>
+                </figure>
+                <figure class="partner-logo">
+                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
+                    <figcaption>Automa</figcaption>
                 </figure>
             </div>
         </div>

--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -206,46 +206,50 @@
     <section class="partners-section" style="padding: 80px 0; background: #f8f9fa;">
         <div class="container">
             <h2 class="section-title" style="text-align: center; margin-bottom: 4rem;">I Nostri Partner</h2>
-            <div class="partners-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem; align-items: center; justify-items: center;">
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Libera Group</figcaption>
+            <div class="partners-grid">
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" />
+                    <figcaption>Libera Group</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Microsoft</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" />
+                    <figcaption>Microsoft</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Bebit</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" />
+                    <figcaption>Bebit</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">OpenAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" />
+                    <figcaption>OpenAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google Gemini</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" />
+                    <figcaption>Google Gemini</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Anthropic</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" />
+                    <figcaption>Anthropic</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">CrewAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" />
+                    <figcaption>CrewAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">ElevenLabs</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" />
+                    <figcaption>ElevenLabs</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" />
+                    <figcaption>Google</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">LangChain</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
+                    <figcaption>LangChain</figcaption>
+                </figure>
+                <figure class="partner-logo">
+                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
+                    <figcaption>Automa</figcaption>
                 </figure>
             </div>
         </div>

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -190,46 +190,50 @@
     <section class="partners-section" style="padding: 80px 0; background: #f8f9fa;">
         <div class="container">
             <h2 class="section-title" style="text-align: center; margin-bottom: 4rem;">I Nostri Partner</h2>
-            <div class="partners-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem; align-items: center; justify-items: center;">
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Libera Group</figcaption>
+            <div class="partners-grid">
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_libera.webp" alt="Libera Group - Partner strategico" loading="lazy" />
+                    <figcaption>Libera Group</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Microsoft</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/microsoft.png" alt="Microsoft - Partner tecnologico" loading="lazy" />
+                    <figcaption>Microsoft</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Bebit</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/logo_footer_bebit.webp" alt="Bebit - Partner tecnologico" loading="lazy" />
+                    <figcaption>Bebit</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">OpenAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/OpenAI_Logo.svg.png" alt="OpenAI - Partner AI" loading="lazy" />
+                    <figcaption>OpenAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google Gemini</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Google_Gemini_logo.svg.png" alt="Google Gemini - Partner AI" loading="lazy" />
+                    <figcaption>Google Gemini</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Anthropic</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/Anthropic_logo.svg.png" alt="Anthropic - Partner AI" loading="lazy" />
+                    <figcaption>Anthropic</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">CrewAI</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/crewai_plus_logo-1.webp" alt="CrewAI - Partner AI" loading="lazy" />
+                    <figcaption>CrewAI</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">ElevenLabs</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/elevenlabs-logo-black.png" alt="ElevenLabs - Partner AI" loading="lazy" />
+                    <figcaption>ElevenLabs</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">Google</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/google-logo.png" alt="Google - Partner tecnologico" loading="lazy" />
+                    <figcaption>Google</figcaption>
                 </figure>
-                <figure class="partner-logo" style="text-align: center; margin: 0;">
-                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" style="max-height: 60px; width: auto; filter: grayscale(100%); transition: filter 0.3s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(100%)'" />
-                    <figcaption style="margin-top: 0.5rem; font-size: 0.9rem; color: var(--medium-gray);">LangChain</figcaption>
+                <figure class="partner-logo">
+                    <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
+                    <figcaption>LangChain</figcaption>
+                </figure>
+                <figure class="partner-logo">
+                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
+                    <figcaption>Automa</figcaption>
                 </figure>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -725,7 +725,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .partners-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 2rem;
     align-items: center;
     justify-items: center;
@@ -777,7 +777,7 @@ h1, h2, h3, h4, h5, h6 {
 
 @media (max-width: 1024px) {
     .partners-grid {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         gap: 1.5rem;
     }
 }


### PR DESCRIPTION
Fixes partner logo sizing issues on landing pages

- Remove inline styles from all landing pages partner sections
- Add missing Automa logo to all affected pages
- Update partner grid to show 5 logos per row on index.html
- Improve responsive breakpoints for better mobile display
- Logo sizing now properly handled by CSS (80px max-height)

Fixes #242

🤖 Generated with [Claude Code](https://claude.ai/code)