### PR TITLE
Update partner sections: set 5 logos per row and remove Automa logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,10 +466,6 @@
                     <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
-                <figure class="partner-logo">
-                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
-                    <figcaption>Automa</figcaption>
-                </figure>
             </div>
         </div>
     </section>

--- a/landing-aeo-geo-enterprise.html
+++ b/landing-aeo-geo-enterprise.html
@@ -228,10 +228,6 @@
                     <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
-                <figure class="partner-logo">
-                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
-                    <figcaption>Automa</figcaption>
-                </figure>
             </div>
         </div>
     </section>

--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -50,13 +50,13 @@
     <style>
         /* Landing page specific styles */
         
-        /* Partners grid fallback */
+        /* Partners grid - 5 logos per row */
         .partners-grid {
-            display: flex;
-            justify-content: center;
-            align-items: center;
+            display: grid;
+            grid-template-columns: repeat(5, 1fr);
             gap: 2rem;
-            flex-wrap: wrap;
+            align-items: center;
+            justify-items: center;
         }
         
         .partner-logo {
@@ -246,10 +246,6 @@
                 <figure class="partner-logo">
                     <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
-                </figure>
-                <figure class="partner-logo">
-                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
-                    <figcaption>Automa</figcaption>
                 </figure>
             </div>
         </div>

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -231,10 +231,6 @@
                     <img src="img/langchain-logo.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
-                <figure class="partner-logo">
-                    <img src="img/automa-logo.png" alt="Automa - Partner AI" loading="lazy" />
-                    <figcaption>Automa</figcaption>
-                </figure>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Fixes #244

Updated partner sections across multiple landing pages:

- Modified `landing-niuexa.html` to display 5 logos per row using CSS grid
- Removed Automa logo from all 4 specified pages
- Partner sections now display 10 logos instead of 11

Generated with [Claude Code](https://claude.ai/code)