### PR TITLE
Fix Formcarry form redirection timing issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -624,14 +624,15 @@ function initFormcarryRedirection() {
     const formcarryForms = document.querySelectorAll('form[action*="formcarry.com"]');
     
     formcarryForms.forEach(form => {
-        form.addEventListener('submit', function(e) {
-            // Don't prevent the default form submission to Formcarry
-            // Instead, add a hidden field to trigger redirection
+        // Check if redirect field already exists to avoid duplicates
+        const existingRedirect = form.querySelector('input[name="_redirect"]');
+        if (!existingRedirect) {
+            // Add redirect field immediately when page loads, not on submit
             const redirectField = document.createElement('input');
             redirectField.type = 'hidden';
             redirectField.name = '_redirect';
             redirectField.value = 'https://niuexa.ai/thank-you-page';
             form.appendChild(redirectField);
-        });
+        }
     });
 }


### PR DESCRIPTION
Fixes form redirection to thank-you page that was not working due to timing issue.

## Changes
- Add _redirect field immediately on page load instead of on form submit
- Prevents timing issue where redirect parameter was added too late
- Check for existing redirect field to avoid duplicates
- Ensures all Formcarry forms redirect to thank-you page correctly

Addresses issue reported in #253 where forms on index.html, contatti.html, landing-niuexa.html, and landing-voice-agent.html were not redirecting properly.

Generated with [Claude Code](https://claude.ai/code)