### PR TITLE
Update footer layout: align copyright left, add Bebit company info right

### DIFF
--- a/includes/includes.js
+++ b/includes/includes.js
@@ -105,7 +105,10 @@ const footerHTML = `
             </div>
         </div>
         <div class="footer-bottom">
-            <p>&copy; 2024 Niuexa. Tutti i diritti riservati.</p>
+            <div class="footer-bottom-content">
+                <p class="footer-copyright">&copy; 2024 Niuexa. Tutti i diritti riservati.</p>
+                <p class="footer-company">Niuexa è una BU di Bebit Srl - P.I. 1121570019</p>
+            </div>
         </div>
     </div>
 </footer>

--- a/landing-marketing-agent.html
+++ b/landing-marketing-agent.html
@@ -469,9 +469,10 @@
     <div id="footer-placeholder"></div>
 
     <!-- ElevenLabs Footer Bar -->
-    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; text-align: center; font-size: 0.9rem; color: var(--medium-gray);">
-        <div class="container">
-            © 2024 Niuexa. Tutti i diritti riservati.
+    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; font-size: 0.9rem; color: var(--medium-gray);">
+        <div class="container" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+            <span style="text-align: left;">© 2024 Niuexa. Tutti i diritti riservati.</span>
+            <span style="text-align: right;">Niuexa è una BU di Bebit Srl - P.I. 1121570019</span>
         </div>
     </div>
 

--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -497,9 +497,10 @@
     <div id="footer-placeholder"></div>
 
     <!-- ElevenLabs Footer Bar -->
-    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; text-align: center; font-size: 0.9rem; color: var(--medium-gray);">
-        <div class="container">
-            © 2024 Niuexa. Tutti i diritti riservati.
+    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; font-size: 0.9rem; color: var(--medium-gray);">
+        <div class="container" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+            <span style="text-align: left;">© 2024 Niuexa. Tutti i diritti riservati.</span>
+            <span style="text-align: right;">Niuexa è una BU di Bebit Srl - P.I. 1121570019</span>
         </div>
     </div>
 

--- a/landing-sales-agent.html
+++ b/landing-sales-agent.html
@@ -469,9 +469,10 @@
     <div id="footer-placeholder"></div>
 
     <!-- ElevenLabs Footer Bar -->
-    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; text-align: center; font-size: 0.9rem; color: var(--medium-gray);">
-        <div class="container">
-            © 2024 Niuexa. Tutti i diritti riservati.
+    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; font-size: 0.9rem; color: var(--medium-gray);">
+        <div class="container" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+            <span style="text-align: left;">© 2024 Niuexa. Tutti i diritti riservati.</span>
+            <span style="text-align: right;">Niuexa è una BU di Bebit Srl - P.I. 1121570019</span>
         </div>
     </div>
 

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -476,9 +476,10 @@
     <div id="footer-placeholder"></div>
 
     <!-- ElevenLabs Footer Bar -->
-    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; text-align: center; font-size: 0.9rem; color: var(--medium-gray);">
-        <div class="container">
-            © 2024 Niuexa. Tutti i diritti riservati.
+    <div class="elevenlabs-footer-bar" style="background: #f8f9fa; border-top: 1px solid #e0e0e0; padding: 12px 0; font-size: 0.9rem; color: var(--medium-gray);">
+        <div class="container" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+            <span style="text-align: left;">© 2024 Niuexa. Tutti i diritti riservati.</span>
+            <span style="text-align: right;">Niuexa è una BU di Bebit Srl - P.I. 1121570019</span>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -2598,6 +2598,24 @@ button[aria-busy="true"]::after {
     color: var(--medium-gray);
 }
 
+.footer-bottom-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.footer-copyright {
+    margin: 0;
+    text-align: left;
+}
+
+.footer-company {
+    margin: 0;
+    text-align: right;
+}
+
 /* Animations */
 @keyframes fadeInUp {
     from {
@@ -2989,6 +3007,16 @@ button[aria-busy="true"]::after {
     .footer-bottom {
         font-size: 0.8rem;
         line-height: 1.4;
+    }
+    
+    .footer-bottom-content {
+        flex-direction: column;
+        text-align: center;
+        gap: 0.5rem;
+    }
+    
+    .footer-copyright, .footer-company {
+        text-align: center;
     }
     
     .footer-disclaimer {


### PR DESCRIPTION
Update footer layout across all pages to align copyright text left and add Bebit company information right-aligned.

Fixes #269

Generated with [Claude Code](https://claude.ai/code)