### PR TITLE
Replace partner logos with PNG versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,11 +473,11 @@
                     <figcaption>ElevenLabs</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/langchain.jpeg" alt="LangChain - Partner AI" loading="lazy" />
+                    <img src="img/LangChain.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/automa.jpeg" alt="Automa - Partner AI" loading="lazy" />
+                    <img src="img/Automa.png" alt="Automa - Partner AI" loading="lazy" />
                     <figcaption>Automa</figcaption>
                 </figure>
             </div>

--- a/landing-niuexa.html
+++ b/landing-niuexa.html
@@ -253,11 +253,11 @@
                     <figcaption>ElevenLabs</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/langchain.jpeg" alt="LangChain - Partner AI" loading="lazy" />
+                    <img src="img/LangChain.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/automa.jpeg" alt="Automa - Partner AI" loading="lazy" />
+                    <img src="img/Automa.png" alt="Automa - Partner AI" loading="lazy" />
                     <figcaption>Automa</figcaption>
                 </figure>
             </div>

--- a/landing-voice-agent.html
+++ b/landing-voice-agent.html
@@ -237,11 +237,11 @@
                     <figcaption>ElevenLabs</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/langchain.jpeg" alt="LangChain - Partner AI" loading="lazy" />
+                    <img src="img/LangChain.png" alt="LangChain - Partner AI" loading="lazy" />
                     <figcaption>LangChain</figcaption>
                 </figure>
                 <figure class="partner-logo">
-                    <img src="img/automa.jpeg" alt="Automa - Partner AI" loading="lazy" />
+                    <img src="img/Automa.png" alt="Automa - Partner AI" loading="lazy" />
                     <figcaption>Automa</figcaption>
                 </figure>
             </div>


### PR DESCRIPTION
Fixes #271

Replace partner logos: langchain.jpeg → LangChain.png, automa.jpeg → Automa.png

## Changes
- Updated index.html partner section
- Updated landing-niuexa.html partner section
- Updated landing-voice-agent.html partner section

Maintains existing styling and behavior while switching to new PNG assets.

Generated with [Claude Code](https://claude.ai/code)