### PR TITLE
Move AEO banner to optimal position between Hero and Chi siamo

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,20 +347,6 @@
     <!-- Navigation Placeholder -->
     <div id="nav-placeholder"></div>
 
-    <!-- AEO Banner -->
-    <div class="aeo-banner">
-        <div class="aeo-banner-container">
-            <div class="aeo-banner-content">
-                <div class="aeo-banner-text">
-                    <h3 class="aeo-banner-title">Il Tuo Sito è <span class="aeo-highlight">Invisibile</span> agli AI?</h3>
-                    <p class="aeo-banner-subtitle">Il 40% delle ricerche avviene tramite ChatGPT, Claude, Perplexity. Scopri se ti trovano e ottimizza la tua AI-discoverability.</p>
-                </div>
-                <div class="aeo-banner-cta">
-                    <a href="ai-readiness-tool.html" class="aeo-banner-btn">Analisi Gratuita</a>
-                </div>
-            </div>
-        </div>
-    </div>
 
     <!-- Hero Section -->
     <section id="home" class="hero">
@@ -398,6 +384,21 @@
             </div>
         </div>
     </section>
+
+    <!-- AEO Banner -->
+    <div class="aeo-banner">
+        <div class="aeo-banner-container">
+            <div class="aeo-banner-content">
+                <div class="aeo-banner-text">
+                    <h3 class="aeo-banner-title">Il Tuo Sito è <span class="aeo-highlight">Invisibile</span> agli AI?</h3>
+                    <p class="aeo-banner-subtitle">Il 40% delle ricerche avviene tramite ChatGPT, Claude, Perplexity. Scopri se ti trovano e ottimizza la tua AI-discoverability.</p>
+                </div>
+                <div class="aeo-banner-cta">
+                    <a href="ai-readiness-tool.html" class="aeo-banner-btn">Analisi Gratuita</a>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Chi Siamo Section -->
     <main id="main-content">


### PR DESCRIPTION
This PR moves the AEO banner from its position before the Hero section to between the Hero section and Chi siamo section as requested in issue #275.

## Changes
- Removed AEO banner from before Hero section
- Repositioned banner between Hero and Chi siamo sections
- Maintained all existing styling and functionality
- Improved user flow and banner positioning

Generated with [Claude Code](https://claude.ai/code)