### PR TITLE
Align resources.html with the site design system and fix dead links

### DIFF
--- a/ai-operator-course.html
+++ b/ai-operator-course.html
@@ -104,7 +104,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->

--- a/ai-operator-series.html
+++ b/ai-operator-series.html
@@ -131,7 +131,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -166,7 +166,7 @@
             <div class="container">
                 <h2>One Series. Every AI Skill You Need.</h2>
                 <p>The AI Operator Series is a carefully sequenced collection of 6 books designed to take you from understanding AI concepts to deploying production-grade AI systems that generate real revenue. Each book stands alone, but together they form the most comprehensive AI business playbook available today.</p>
-                <p style="margin-top: 15px;">Whether you are a CTO designing enterprise integrations, a solo founder building a one-person AI business, or a business operator looking for no-code automations — there is a book written specifically for your goals, your skill level, and your timeline.</p>
+                <p>Whether you are a CTO designing enterprise integrations, a solo founder building a one-person AI business, or a business operator looking for no-code automations — there is a book written specifically for your goals, your skill level, and your timeline.</p>
             </div>
         </section>
 
@@ -197,7 +197,7 @@
                         </div>
                         <div class="book-card-footer">
                             <a href="/en/contact.html" class="btn btn-primary">Get the Book</a>
-                            <a href="resources.html" class="btn btn-secondary">Resources</a>
+                            <a href="books/mcp-blueprint/resources.html" class="btn btn-secondary">Resources</a>
                         </div>
                     </div>
 
@@ -220,7 +220,7 @@
                         </div>
                         <div class="book-card-footer">
                             <a href="/en/contact.html" class="btn btn-primary">Get the Book</a>
-                            <a href="resources.html" class="btn btn-secondary">Resources</a>
+                            <a href="books/one-person-empire/resources.html" class="btn btn-secondary">Resources</a>
                         </div>
                     </div>
 
@@ -243,7 +243,7 @@
                         </div>
                         <div class="book-card-footer">
                             <a href="/en/contact.html" class="btn btn-primary">Get the Book</a>
-                            <a href="resources.html" class="btn btn-secondary">Resources</a>
+                            <a href="books/no-code-ai-bible/resources.html" class="btn btn-secondary">Resources</a>
                         </div>
                     </div>
 
@@ -266,7 +266,7 @@
                         </div>
                         <div class="book-card-footer">
                             <a href="/en/contact.html" class="btn btn-primary">Get the Book</a>
-                            <a href="resources.html" class="btn btn-secondary">Resources</a>
+                            <a href="books/ai-agents-field-guide/resources.html" class="btn btn-secondary">Resources</a>
                         </div>
                     </div>
 

--- a/books.css
+++ b/books.css
@@ -118,6 +118,12 @@
     color: var(--medium-gray);
 }
 
+/* The global reset zeroes paragraph margins, so stacked copy needs its gap
+   back. Pages used to do this with style="margin-top: 15px" on the second p. */
+.series-intro p + p {
+    margin-top: 15px;
+}
+
 /* Book Grid */
 .books-section {
     padding: var(--section-padding);
@@ -371,6 +377,10 @@
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
     border-left: 3px solid var(--primary-blue);
     transition: transform var(--transition-fast);
+    /* Grid already stretches the cards to a shared height; the column layout
+       is what pushes each card's button down to a common baseline. */
+    display: flex;
+    flex-direction: column;
 }
 
 .channel-card:hover {
@@ -390,6 +400,11 @@
     color: var(--medium-gray);
     line-height: 1.6;
     margin-bottom: 15px;
+    flex: 1;
+}
+
+.channel-card .btn {
+    align-self: flex-start;
 }
 
 /* --- Newsletter Page --- */
@@ -474,11 +489,29 @@
     background: var(--white);
 }
 
+/* Section tint modifiers. These backgrounds used to be written as
+   `style="background: var(--light-gray)"` on the section itself; keeping them
+   here lets a page alternate white/tinted bands without inline overrides. */
+.resources-section--alt {
+    background: var(--light-gray);
+}
+
+.community-channels--alt {
+    background: var(--white);
+}
+
 .resources-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
     gap: 25px;
     margin-top: 40px;
+}
+
+/* Two-up variant, declared after the base so it actually wins. 300px tracks
+   fit three across inside the 1200px container, which strands a fourth card
+   alone on its own row; link-dense cards read better two-up anyway. */
+.resources-grid--two {
+    grid-template-columns: repeat(auto-fit, minmax(min(420px, 100%), 1fr));
 }
 
 .resource-card {
@@ -550,6 +583,124 @@
 
 .resource-card .btn {
     align-self: flex-start;
+}
+
+/* Icon + type badge share one row so the card keeps a shallow header instead
+   of stacking two full-width blocks above the title. */
+.resource-card-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.resource-card-head .resource-type {
+    margin-bottom: 0;
+}
+
+.resource-icon {
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--gradient-light);
+    /* Stroked icons inherit this, so it doubles as the AA-safe icon colour. */
+    color: var(--blue-text);
+}
+
+.resource-icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+/* Checklist inside a card. This was repeated as inline styles on every <li>
+   across the resource and community pages; the checkmark also used
+   --primary-green, which is a fill token and misses AA as text. */
+.resource-features {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 20px;
+}
+
+.resource-features li {
+    font-family: var(--font-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: var(--dark-gray);
+    padding: 5px 0 5px 24px;
+    position: relative;
+}
+
+.resource-features li::before {
+    content: '\2713';
+    position: absolute;
+    left: 0;
+    top: 5px;
+    color: var(--green-text);
+    font-weight: 700;
+}
+
+/* Channel lists mark rooms, not completed items. */
+.resource-features--hash li::before {
+    content: '#';
+}
+
+.resource-features a {
+    color: var(--blue-text);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+    transition: color var(--transition-fast);
+}
+
+.resource-features a:hover,
+.resource-features a:focus-visible {
+    color: var(--signal);
+    text-decoration-thickness: 2px;
+}
+
+/* --- Hub Stats Band --- */
+.hub-stats {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: clamp(28px, 6vw, 60px);
+    margin-bottom: 40px;
+}
+
+.hub-stat {
+    text-align: center;
+}
+
+.hub-stat-value {
+    font-family: var(--font-primary);
+    font-size: clamp(2rem, 4vw, 3rem);
+    font-weight: 700;
+    line-height: 1.1;
+    background: var(--gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.hub-stat-label {
+    font-family: var(--font-secondary);
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--medium-gray);
+}
+
+/* Clipping the gradient to the glyphs makes them transparent, which forced
+   colour modes render as nothing at all. */
+@media (forced-colors: active) {
+    .hub-stat-value {
+        background: none;
+        -webkit-text-fill-color: currentColor;
+        color: CanvasText;
+    }
 }
 
 /* --- Lead Magnet / Download Pages --- */
@@ -943,6 +1094,34 @@
     background: var(--light-gray);
 }
 
+/* Lower-emphasis second action in a CTA banner. Pages wrote this as inline
+   border-color/color overrides; two solid white buttons side by side gave the
+   secondary choice the same weight as the primary one. */
+.book-cta .btn-ghost {
+    background: transparent;
+    color: var(--white);
+    border: 2px solid var(--white);
+}
+
+.book-cta .btn-ghost:hover,
+.book-cta .btn-ghost:focus-visible {
+    background: var(--white);
+    color: var(--blue-text);
+}
+
+/* Centred row of one or two actions. Shared so a CTA banner and a plain
+   intro section space their buttons the same way. */
+.cta-actions {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.series-intro .cta-actions {
+    margin-top: 25px;
+}
+
 /* --- Section Titles (shared) --- */
 .section-header {
     text-align: center;
@@ -1242,6 +1421,10 @@
     .preview-grid,
     .checklist-categories {
         grid-template-columns: 1fr;
+    }
+
+    .hub-stats {
+        gap: 24px 32px;
     }
 }
 

--- a/books/ai-agents-field-guide/checklist.html
+++ b/books/ai-agents-field-guide/checklist.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/ai-agents-field-guide/frameworks.html
+++ b/books/ai-agents-field-guide/frameworks.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/ai-agents-field-guide/resources.html
+++ b/books/ai-agents-field-guide/resources.html
@@ -105,7 +105,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css?v=20260711">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -172,14 +172,25 @@
             </div>
         </section>
 
+        <!-- Cross-links -->
+        <section class="series-intro">
+            <div class="container">
+                <h2>More From the AI Operator Series</h2>
+                <p>The AI Agents Field Guide is book four of four. Every companion resource across the series — server templates, prompt libraries, ROI calculators, automation blueprints and rollout roadmaps — is indexed in one place.</p>
+                <div class="cta-actions">
+                    <a href="../../resources.html" class="btn btn-primary">Browse All Resources</a>
+                </div>
+            </div>
+        </section>
+
         <!-- CTA -->
-        <section class="cta-section" style="background: var(--gradient-primary); color: var(--white); padding: 80px 0;">
-            <div class="container" style="text-align: center;">
-                <h2 style="color: var(--white); font-family: var(--font-primary); margin-bottom: 1rem;">Need help shipping your first agent?</h2>
-                <p style="max-width: 720px; margin: 0 auto 2rem; opacity: 0.95;">Book a free 30-minute working session with a Niuexa engineer. We'll review your architecture, flag the riskiest items on the checklist, and give you a concrete next step.</p>
-                <div class="hero-buttons" style="justify-content: center;">
-                    <a href="../../en/consulting.html" class="btn btn-secondary" style="background: var(--white); color: var(--primary-blue); border-color: var(--white);">Book a Working Session</a>
-                    <a href="../../ai-operator-series.html" class="btn btn-secondary" style="border-color: var(--white); color: var(--white);">Browse the Series</a>
+        <section class="book-cta">
+            <div class="container">
+                <h2>Need help shipping your first agent?</h2>
+                <p>Book a free 30-minute working session with a Niuexa engineer. We'll review your architecture, flag the riskiest items on the checklist, and give you a concrete next step.</p>
+                <div class="cta-actions">
+                    <a href="../../en/consulting.html" class="btn btn-secondary">Book a Working Session</a>
+                    <a href="../../ai-operator-series.html" class="btn btn-ghost">Browse the Series</a>
                 </div>
             </div>
         </section>

--- a/books/ai-agents-field-guide/runbook.html
+++ b/books/ai-agents-field-guide/runbook.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/mcp-blueprint/breaches.html
+++ b/books/mcp-blueprint/breaches.html
@@ -71,7 +71,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/mcp-blueprint/resources.html
+++ b/books/mcp-blueprint/resources.html
@@ -93,7 +93,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -155,12 +155,12 @@
                         <a href="roadmap-template.html" class="btn btn-primary">Download Roadmap</a>
                     </div>
 
-                    <!-- GitHub Repository -->
+                    <!-- Full Library -->
                     <div class="resource-card">
-                        <span class="resource-type github">GitHub</span>
-                        <h3>GitHub Repository</h3>
-                        <p>All code examples from the book in a single, runnable repository. Organized by chapter with clear README files, test suites, and CI/CD configurations. Clone it, run the tests, and use it as a starting point for your own MCP servers.</p>
-                        <a href="https://github.com/gregormaric/mcp-blueprint" target="_blank" rel="noopener noreferrer" class="btn btn-primary">View on GitHub</a>
+                        <span class="resource-type">Library</span>
+                        <h3>Complete Resource Library</h3>
+                        <p>The MCP Blueprint is book one of four. The full AI Operator library collects every companion resource across the series — templates, calculators, checklists and runbooks — indexed by book and by type.</p>
+                        <a href="../../resources.html" class="btn btn-primary">Browse All Resources</a>
                     </div>
 
                     <!-- Video Walkthroughs -->

--- a/books/mcp-blueprint/roadmap-template.html
+++ b/books/mcp-blueprint/roadmap-template.html
@@ -71,7 +71,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/mcp-blueprint/starter-kit.html
+++ b/books/mcp-blueprint/starter-kit.html
@@ -71,7 +71,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/no-code-ai-bible/chapter-1.html
+++ b/books/no-code-ai-bible/chapter-1.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/no-code-ai-bible/community.html
+++ b/books/no-code-ai-bible/community.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/no-code-ai-bible/demo.html
+++ b/books/no-code-ai-bible/demo.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/no-code-ai-bible/resources.html
+++ b/books/no-code-ai-bible/resources.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -130,10 +130,10 @@
                         <a href="community.html" class="btn btn-primary">Join Community</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type github">GitHub</span>
-                        <h3>GitHub Configs</h3>
-                        <p>All configuration files, JSON templates, and code snippets referenced in the book are maintained in a public GitHub repository. Star it to get notified when new templates are added or existing ones are updated with platform changes.</p>
-                        <a href="https://github.com/gregormaric/no-code-ai-bible" class="btn btn-primary" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+                        <span class="resource-type">Library</span>
+                        <h3>Complete Resource Library</h3>
+                        <p>The No-Code AI Bible is book three of four. The full AI Operator library indexes every companion resource across the series — templates, prompts, calculators, checklists and runbooks — by book and by type.</p>
+                        <a href="../../resources.html" class="btn btn-primary">Browse All Resources</a>
                     </div>
                     <div class="resource-card">
                         <span class="resource-type download">Download</span>

--- a/books/no-code-ai-bible/templates.html
+++ b/books/no-code-ai-bible/templates.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/one-person-empire/prompts.html
+++ b/books/one-person-empire/prompts.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/one-person-empire/resources.html
+++ b/books/one-person-empire/resources.html
@@ -24,7 +24,7 @@
     </script>
 
     <title>The One-Person Empire — Resources | AI Operator Series</title>
-    <meta name="description" content="Companion page for The One-Person Empire: the $215 stack breakdown, AI sales rep demo, agent prompt templates, ROI calculator, GitHub repo, and community.">
+    <meta name="description" content="Companion page for The One-Person Empire: the $215 stack breakdown, AI sales rep demo, agent prompt templates, ROI calculator, and community.">
     <meta name="keywords" content="one person empire resources, AI operator series, solo AI business, AI consulting book, solopreneur resources, AI business tools">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="author" content="Gregor Maric">
@@ -90,7 +90,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -151,10 +151,10 @@
                         <a href="roi-calculator.html" class="btn btn-primary">Get Calculator</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type github">GitHub</span>
-                        <h3>GitHub Repository</h3>
-                        <p>All code samples, configuration files, and automation scripts from the book. Fork the repo, follow along with the chapters, and contribute your own improvements.</p>
-                        <a href="https://github.com/gregormaric/one-person-empire" target="_blank" rel="noopener noreferrer" class="btn btn-primary">View on GitHub</a>
+                        <span class="resource-type">Library</span>
+                        <h3>Complete Resource Library</h3>
+                        <p>Every companion resource across all four books of the AI Operator Series in one index — stacks, prompts, templates, checklists and calculators, grouped by book and by type.</p>
+                        <a href="../../resources.html" class="btn btn-primary">Browse All Resources</a>
                     </div>
                     <div class="resource-card">
                         <span class="resource-type community">Community</span>
@@ -211,7 +211,7 @@
                         <ul>
                             <li>Complete eBook (PDF, EPUB, MOBI)</li>
                             <li>All downloadable resources</li>
-                            <li>GitHub repository access</li>
+                            <li>Prompt library &amp; stack breakdown</li>
                             <li>Lifetime updates &amp; errata</li>
                             <li>Community access</li>
                         </ul>

--- a/books/one-person-empire/roi-calculator.html
+++ b/books/one-person-empire/roi-calculator.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/one-person-empire/sales-demo.html
+++ b/books/one-person-empire/sales-demo.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/books/one-person-empire/stack.html
+++ b/books/one-person-empire/stack.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="../../books.css">
+    <link rel="stylesheet" href="../../books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/community.html
+++ b/community.html
@@ -106,7 +106,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -140,18 +140,18 @@
         <!-- Community Stats -->
         <section class="series-intro">
             <div class="container">
-                <div style="display: flex; justify-content: center; gap: 60px; flex-wrap: wrap; margin-bottom: 40px;">
-                    <div style="text-align: center;">
-                        <div style="font-family: var(--font-primary); font-size: clamp(2rem, 4vw, 3rem); font-weight: 900; background: var(--gradient-primary); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">500+</div>
-                        <div style="font-family: var(--font-secondary); font-size: 1rem; color: var(--medium-gray); font-weight: 500;">Members</div>
+                <div class="hub-stats">
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">500+</div>
+                        <div class="hub-stat-label">Members</div>
                     </div>
-                    <div style="text-align: center;">
-                        <div style="font-family: var(--font-primary); font-size: clamp(2rem, 4vw, 3rem); font-weight: 900; background: var(--gradient-primary); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">4</div>
-                        <div style="font-family: var(--font-secondary); font-size: 1rem; color: var(--medium-gray); font-weight: 500;">Books</div>
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">4</div>
+                        <div class="hub-stat-label">Books</div>
                     </div>
-                    <div style="text-align: center;">
-                        <div style="font-family: var(--font-primary); font-size: clamp(2rem, 4vw, 3rem); font-weight: 900; background: var(--gradient-primary); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Weekly</div>
-                        <div style="font-family: var(--font-secondary); font-size: 1rem; color: var(--medium-gray); font-weight: 500;">Live Sessions</div>
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">Weekly</div>
+                        <div class="hub-stat-label">Live Sessions</div>
                     </div>
                 </div>
                 <h2>Built for Operators, Not Observers</h2>
@@ -212,32 +212,32 @@
                     <div class="channel-card">
                         <h3>Discord — Main Hub</h3>
                         <p>Our primary community space with dedicated channels for each book, tool recommendations, job postings, show-and-tell, and general discussion. This is where the real-time conversations happen.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 15px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">#</span> mcp-blueprint</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">#</span> one-person-empire</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">#</span> no-code-recipes</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">#</span> ai-agents-field-guide</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">#</span> show-and-tell</li>
+                        <ul class="resource-features resource-features--hash">
+                            <li>mcp-blueprint</li>
+                            <li>one-person-empire</li>
+                            <li>no-code-recipes</li>
+                            <li>ai-agents-field-guide</li>
+                            <li>show-and-tell</li>
                         </ul>
                         <a href="https://discord.gg/vyKckeS3" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Join Discord</a>
                     </div>
                     <div class="channel-card">
                         <h3>Monthly AMAs</h3>
                         <p>Every first Thursday of the month, join a live Ask Me Anything session with the series authors and guest experts. Topics range from AI strategy to technical deep-dives on specific tools and frameworks.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 15px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> First Thursday monthly</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Guest industry experts</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Recorded &amp; replayable</li>
+                        <ul class="resource-features">
+                            <li>First Thursday monthly</li>
+                            <li>Guest industry experts</li>
+                            <li>Recorded &amp; replayable</li>
                         </ul>
                         <a href="newsletter.html" class="btn btn-secondary">Get Reminders</a>
                     </div>
                     <div class="channel-card">
                         <h3>Book Study Groups</h3>
                         <p>Join a cohort of readers working through the same book. Each study group meets weekly for 4-6 weeks, with structured discussions, accountability partners, and implementation challenges.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 15px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> 4-6 week cohorts</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Accountability partners</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Implementation challenges</li>
+                        <ul class="resource-features">
+                            <li>4-6 week cohorts</li>
+                            <li>Accountability partners</li>
+                            <li>Implementation challenges</li>
                         </ul>
                         <a href="https://discord.gg/vyKckeS3" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Find a Group</a>
                     </div>

--- a/en/includes/navigation-en.js
+++ b/en/includes/navigation-en.js
@@ -349,6 +349,22 @@ function getCurrentPage() {
     const path = window.location.pathname;
     const page = path.split('/').pop();
 
+    // The AI Operator Series cluster has no nav entry of its own — every one
+    // of these pages is reached through "Resources > Free Resources". Without
+    // this the fall-through at the bottom returned 'home', so the whole
+    // cluster lit up the Home link instead.
+    var FREE_RESOURCE_PAGES = [
+        'resources.html',
+        'ai-operator-series.html',
+        'ai-operator-course.html',
+        'community.html',
+        'newsletter.html',
+        'nocode-toolkit.html'
+    ];
+    if (FREE_RESOURCE_PAGES.indexOf(page) !== -1 || path.indexOf('/books/') === 0) {
+        return 'free-resources';
+    }
+
     if (page === 'index.html' || page === '') {
         return 'home';
     } else if (page === 'about-us.html') {

--- a/newsletter.html
+++ b/newsletter.html
@@ -106,7 +106,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->

--- a/nocode-toolkit.html
+++ b/nocode-toolkit.html
@@ -69,7 +69,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KG9S42S4" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/resources.html
+++ b/resources.html
@@ -26,8 +26,8 @@
     </script>
 
     <title>AI Operator Resources | Companion Library for the AI Operator Series | Niuexa</title>
-    <meta name="description" content="Companion library for the AI Operator Series: templates, code repos and resources for MCP Blueprint, One-Person Empire, No-Code AI Bible and AI Agents Field Guide.">
-    <meta name="keywords" content="AI operator resources, MCP blueprint resources, AI business templates, no-code AI templates, AI agents code, AI operator series companion, AI book resources">
+    <meta name="description" content="Free companion library for the AI Operator Series: 18 templates, checklists, calculators and runbooks for MCP Blueprint, One-Person Empire, No-Code AI Bible and AI Agents Field Guide.">
+    <meta name="keywords" content="AI operator resources, MCP blueprint resources, AI business templates, no-code AI templates, AI agent checklists, AI operator series companion, AI book resources">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <meta name="author" content="Niuexa">
     <link rel="canonical" href="https://niuexa.ai/resources.html">
@@ -35,7 +35,7 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="AI Operator Resources | Companion Library">
-    <meta property="og:description" content="Your companion library for the AI Operator Series. Access resources, templates, code repos, and supplementary materials for all books.">
+    <meta property="og:description" content="Your companion library for the AI Operator Series. 18 free templates, checklists, calculators and runbooks across all four books.">
     <meta property="og:image" content="https://niuexa.ai/img/niuexalogo.png">
     <meta property="og:url" content="https://niuexa.ai/resources.html">
     <meta property="og:site_name" content="Niuexa">
@@ -44,7 +44,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Operator Resources | Companion Library">
-    <meta name="twitter:description" content="Your companion library for the AI Operator Series. Templates, code repos, and supplementary materials for all books.">
+    <meta name="twitter:description" content="Your companion library for the AI Operator Series. 18 free templates, checklists, calculators and runbooks across all four books.">
     <meta name="twitter:image" content="https://niuexa.ai/img/niuexalogo.png">
 
     <!-- Hreflang -->
@@ -63,8 +63,14 @@
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "AI Operator Resources",
-        "description": "Your companion library for the AI Operator Series. Access resources, templates, code repositories, and supplementary materials for all books.",
+        "description": "Your companion library for the AI Operator Series. Templates, checklists, calculators, runbooks and supplementary materials for all books.",
         "url": "https://niuexa.ai/resources.html",
+        "inLanguage": "en",
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": "Niuexa",
+            "url": "https://niuexa.ai/"
+        },
         "publisher": {
             "@type": "Organization",
             "name": "Niuexa",
@@ -72,6 +78,31 @@
                 "@type": "ImageObject",
                 "url": "https://niuexa.ai/img/niuexalogo.png"
             }
+        },
+        "mainEntity": {
+            "@type": "ItemList",
+            "name": "AI Operator Series companion resources",
+            "numberOfItems": 18,
+            "itemListElement": [
+                { "@type": "ListItem", "position": 1, "name": "The MCP Blueprint — Resources", "url": "https://niuexa.ai/books/mcp-blueprint/resources.html" },
+                { "@type": "ListItem", "position": 2, "name": "MCP Starter Kit", "url": "https://niuexa.ai/books/mcp-blueprint/starter-kit.html" },
+                { "@type": "ListItem", "position": 3, "name": "90-Day MCP Implementation Roadmap", "url": "https://niuexa.ai/books/mcp-blueprint/roadmap-template.html" },
+                { "@type": "ListItem", "position": 4, "name": "AI Security Breach Timeline", "url": "https://niuexa.ai/books/mcp-blueprint/breaches.html" },
+                { "@type": "ListItem", "position": 5, "name": "The One-Person Empire — Resources", "url": "https://niuexa.ai/books/one-person-empire/resources.html" },
+                { "@type": "ListItem", "position": 6, "name": "The $215/Month AI Business Stack", "url": "https://niuexa.ai/books/one-person-empire/stack.html" },
+                { "@type": "ListItem", "position": 7, "name": "Production-Ready Agent Prompts", "url": "https://niuexa.ai/books/one-person-empire/prompts.html" },
+                { "@type": "ListItem", "position": 8, "name": "AI Automation ROI Calculator", "url": "https://niuexa.ai/books/one-person-empire/roi-calculator.html" },
+                { "@type": "ListItem", "position": 9, "name": "AI Sales Rep Demo Preview", "url": "https://niuexa.ai/books/one-person-empire/sales-demo.html" },
+                { "@type": "ListItem", "position": 10, "name": "The No-Code AI Bible — Resources", "url": "https://niuexa.ai/books/no-code-ai-bible/resources.html" },
+                { "@type": "ListItem", "position": 11, "name": "32 Free No-Code AI Automation Templates", "url": "https://niuexa.ai/books/no-code-ai-bible/templates.html" },
+                { "@type": "ListItem", "position": 12, "name": "No-Code AI Starter Pack", "url": "https://niuexa.ai/books/no-code-ai-bible/chapter-1.html" },
+                { "@type": "ListItem", "position": 13, "name": "Building an AI Automation Live — Demo", "url": "https://niuexa.ai/books/no-code-ai-bible/demo.html" },
+                { "@type": "ListItem", "position": 14, "name": "No-Code AI Builders Community", "url": "https://niuexa.ai/books/no-code-ai-bible/community.html" },
+                { "@type": "ListItem", "position": 15, "name": "The AI Agents Field Guide — Resources", "url": "https://niuexa.ai/books/ai-agents-field-guide/resources.html" },
+                { "@type": "ListItem", "position": 16, "name": "Agent Production Readiness Checklist", "url": "https://niuexa.ai/books/ai-agents-field-guide/checklist.html" },
+                { "@type": "ListItem", "position": 17, "name": "AI Agent Framework Comparison 2026", "url": "https://niuexa.ai/books/ai-agents-field-guide/frameworks.html" },
+                { "@type": "ListItem", "position": 18, "name": "AI Agent Incident Response Runbook", "url": "https://niuexa.ai/books/ai-agents-field-guide/runbook.html" }
+            ]
         },
         "breadcrumb": {
             "@type": "BreadcrumbList",
@@ -106,7 +137,7 @@
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="styles.css?v=20260807">
-    <link rel="stylesheet" href="books.css">
+    <link rel="stylesheet" href="books.css?v=20260811">
 </head>
 <body>
     <!-- Google Tag Manager (noscript) -->
@@ -117,7 +148,7 @@
     <main id="main-content">
         <!-- Hero Section -->
         <section class="book-hero">
-            <nav class="book-breadcrumb">
+            <nav class="book-breadcrumb" aria-label="Breadcrumb">
                 <div class="container">
                     <ol>
                         <li><a href="index.html">Home</a></li>
@@ -129,10 +160,10 @@
             <div class="container">
                 <span class="hero-badge">Companion Library</span>
                 <h1 class="hero-title"><span class="highlight">AI Operator</span> Resources</h1>
-                <p class="hero-subtitle">Your companion library for the AI Operator Series. Templates, code repositories, checklists, video walkthroughs, and supplementary materials — organized by book.</p>
+                <p class="hero-subtitle">Your companion library for the AI Operator Series. Templates, checklists, calculators, runbooks, and video walkthroughs — organized by book and by type, every one of them a page you can open right now.</p>
                 <div class="hero-buttons">
                     <a href="#book-resources" class="btn btn-primary">Browse by Book</a>
-                    <a href="#cross-book" class="btn btn-secondary">Cross-Book Resources</a>
+                    <a href="#by-type" class="btn btn-secondary">Browse by Type</a>
                 </div>
             </div>
         </section>
@@ -140,80 +171,114 @@
         <!-- How Resources Work -->
         <section class="series-intro">
             <div class="container">
+                <div class="hub-stats">
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">18</div>
+                        <div class="hub-stat-label">Resource Pages</div>
+                    </div>
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">4</div>
+                        <div class="hub-stat-label">Book Libraries</div>
+                    </div>
+                    <div class="hub-stat">
+                        <div class="hub-stat-value">Free</div>
+                        <div class="hub-stat-label">For Book Owners</div>
+                    </div>
+                </div>
                 <h2>How to Use This Library</h2>
                 <p>Every book in the AI Operator Series has a dedicated resource page with all the companion materials referenced in the text. Look for the "Resources" icon at the end of each chapter for direct links. All resources are free for book owners and updated regularly as tools and best practices evolve.</p>
             </div>
         </section>
 
         <!-- Book-Specific Resources -->
-        <section id="book-resources" class="resources-section">
+        <section id="book-resources" class="resources-section resources-section--alt">
             <div class="container">
                 <div class="section-header">
                     <h2>Resources by Book</h2>
-                    <p>Select a book to access its dedicated companion library.</p>
+                    <p>Four companion libraries. Every item below links straight to the resource — no gate, no download form.</p>
                 </div>
-                <div class="resources-grid">
+                <div class="resources-grid resources-grid--two">
                     <!-- MCP Blueprint Resources -->
                     <div class="resource-card">
-                        <span class="resource-type">Book 1</span>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="8" height="8" rx="1"></rect><rect x="14" y="14" width="8" height="8" rx="1"></rect><path d="M6 10v4a2 2 0 0 0 2 2h6"></path><path d="M18 14v-4a2 2 0 0 0-2-2h-6"></path></svg>
+                            </span>
+                            <span class="resource-type">Book 1</span>
+                        </div>
                         <h3>The MCP Blueprint Resources</h3>
-                        <p>Architecture diagrams, MCP server templates, security checklists, integration code samples, and deployment guides referenced throughout The MCP Blueprint.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 20px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> 12 MCP server templates</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Architecture decision records</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Security audit checklist</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Video walkthroughs</li>
+                        <p>Server templates, a phased rollout plan, and the security research behind The MCP Blueprint — everything referenced in the book, on one page.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/mcp-blueprint/starter-kit.html">MCP Starter Kit</a> — pre-configured server templates</li>
+                            <li><a href="books/mcp-blueprint/roadmap-template.html">90-Day Implementation Roadmap</a></li>
+                            <li><a href="books/mcp-blueprint/breaches.html">AI Security Breach Timeline</a></li>
+                            <li><a href="https://www.youtube.com/@NiuexaChampion" target="_blank" rel="noopener noreferrer">Video walkthroughs</a></li>
                         </ul>
-                        <a href="books/mcp-blueprint/resources.html" class="btn btn-primary">Access Resources</a>
+                        <a href="books/mcp-blueprint/resources.html" class="btn btn-primary">Open Book 1 Library</a>
                     </div>
 
                     <!-- One-Person Empire Resources -->
                     <div class="resource-card">
-                        <span class="resource-type">Book 2</span>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+                            </span>
+                            <span class="resource-type">Book 2</span>
+                        </div>
                         <h3>The One-Person Empire Resources</h3>
-                        <p>Business model canvases, pricing calculators, client proposal templates, automation workflow blueprints, and financial planning spreadsheets for solo AI operators.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 20px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Business model canvas templates</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Pricing calculator spreadsheet</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Client proposal templates</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Automation blueprints</li>
+                        <p>The tool stack, the prompts, and the numbers behind a solo AI consulting business — the working files from The One-Person Empire.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/one-person-empire/stack.html">The $215/Month AI Business Stack</a></li>
+                            <li><a href="books/one-person-empire/prompts.html">Production-Ready Agent Prompts</a></li>
+                            <li><a href="books/one-person-empire/roi-calculator.html">AI Automation ROI Calculator</a></li>
+                            <li><a href="books/one-person-empire/sales-demo.html">AI Sales Rep Demo</a></li>
                         </ul>
-                        <a href="books/one-person-empire/resources.html" class="btn btn-primary">Access Resources</a>
+                        <a href="books/one-person-empire/resources.html" class="btn btn-primary">Open Book 2 Library</a>
                     </div>
 
                     <!-- No-Code AI Bible Resources -->
                     <div class="resource-card">
-                        <span class="resource-type">Book 3</span>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+                            </span>
+                            <span class="resource-type">Book 3</span>
+                        </div>
                         <h3>The No-Code AI Bible Resources</h3>
-                        <p>Pre-built automation templates for Make and Zapier, prompt libraries, screenshot guides, video tutorials for each of the 32 recipes, and tool comparison matrices.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 20px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> 32 automation template files</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Prompt library (copy-paste ready)</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Video tutorial per recipe</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Tool comparison matrices</li>
+                        <p>Importable automation templates for Make, Zapier and n8n, plus the live build demo and the monthly pricing guide for every tool in the book.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/no-code-ai-bible/templates.html">32 Automation Templates</a></li>
+                            <li><a href="books/no-code-ai-bible/chapter-1.html">No-Code AI Starter Pack</a></li>
+                            <li><a href="books/no-code-ai-bible/demo.html">Live Build Demo</a></li>
+                            <li><a href="books/no-code-ai-bible/community.html">Builders Community</a></li>
                         </ul>
-                        <a href="books/no-code-ai-bible/resources.html" class="btn btn-primary">Access Resources</a>
+                        <a href="books/no-code-ai-bible/resources.html" class="btn btn-primary">Open Book 3 Library</a>
                     </div>
 
                     <!-- AI Agents Field Guide Resources -->
                     <div class="resource-card">
-                        <span class="resource-type">Book 4</span>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="8" width="16" height="12" rx="2"></rect><path d="M12 8V4"></path><circle cx="12" cy="3" r="1"></circle><path d="M9 13h.01"></path><path d="M15 13h.01"></path><path d="M9.5 17h5"></path></svg>
+                            </span>
+                            <span class="resource-type">Book 4</span>
+                        </div>
                         <h3>The AI Agents Field Guide Resources</h3>
-                        <p>Agent starter kits, testing frameworks, monitoring dashboards, evaluation harnesses, and production deployment checklists for every agent pattern covered in the book.</p>
-                        <ul style="list-style: none; padding: 0; margin: 0 0 20px 0;">
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Agent starter kit repositories</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Testing &amp; eval frameworks</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Monitoring dashboard configs</li>
-                            <li style="font-family: var(--font-secondary); font-size: 0.9rem; color: var(--dark-gray); padding: 4px 0; padding-left: 22px; position: relative;"><span style="position: absolute; left: 0; color: var(--primary-green); font-weight: 700;">&#10003;</span> Deployment checklists</li>
+                        <p>What you need between a working prototype and a production agent: a readiness checklist, a framework comparison, and an incident runbook.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/ai-agents-field-guide/checklist.html">Production Readiness Checklist</a></li>
+                            <li><a href="books/ai-agents-field-guide/frameworks.html">Agent Framework Comparison 2026</a></li>
+                            <li><a href="books/ai-agents-field-guide/runbook.html">Incident Response Runbook</a></li>
+                            <li><a href="/en/consulting.html">Book a working session with our team</a></li>
                         </ul>
-                        <a href="books/ai-agents-field-guide/resources.html" class="btn btn-primary">Access Resources</a>
+                        <a href="books/ai-agents-field-guide/resources.html" class="btn btn-primary">Open Book 4 Library</a>
                     </div>
                 </div>
             </div>
         </section>
 
         <!-- Cross-Book Resources -->
-        <section id="cross-book" class="community-channels" style="background: var(--light-gray);">
+        <section id="cross-book" class="community-channels community-channels--alt">
             <div class="container">
                 <div class="section-header">
                     <h2>Cross-Book Resources</h2>
@@ -222,17 +287,33 @@
                 <div class="channels-grid">
                     <div class="channel-card">
                         <h3>Community</h3>
-                        <p>Join 500+ operators on Discord for real-time Q&A, shared templates, weekly live sessions, book study groups, and direct access to the authors. Free for all book owners.</p>
+                        <p>Join 500+ operators on Discord for real-time Q&amp;A, shared templates, weekly live sessions, book study groups, and direct access to the authors. Free for all book owners.</p>
+                        <ul class="resource-features resource-features--hash">
+                            <li>mcp-blueprint</li>
+                            <li>one-person-empire</li>
+                            <li>no-code-recipes</li>
+                            <li>ai-agents-field-guide</li>
+                        </ul>
                         <a href="community.html" class="btn btn-primary">Join Community</a>
                     </div>
                     <div class="channel-card">
                         <h3>Newsletter</h3>
                         <p>The AI Operator Newsletter delivers weekly insights on AI automation, tool reviews, automation recipes, and exclusive discounts. Free, 5-minute read every Tuesday.</p>
+                        <ul class="resource-features">
+                            <li>New resources announced first</li>
+                            <li>Tool and pricing changes</li>
+                            <li>One email a week, unsubscribe anytime</li>
+                        </ul>
                         <a href="newsletter.html" class="btn btn-primary">Subscribe Free</a>
                     </div>
                     <div class="channel-card">
                         <h3>YouTube Channel</h3>
                         <p>Video walkthroughs, tool demos, and deep-dive tutorials that complement the books. New content weekly covering implementation guides and live coding sessions.</p>
+                        <ul class="resource-features">
+                            <li>Implementation walkthroughs</li>
+                            <li>Live coding sessions</li>
+                            <li>Tool demos and comparisons</li>
+                        </ul>
                         <a href="https://www.youtube.com/@NiuexaChampion" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Watch Videos</a>
                     </div>
                 </div>
@@ -240,53 +321,119 @@
         </section>
 
         <!-- Resource Categories -->
-        <section class="resources-section">
+        <section id="by-type" class="resources-section resources-section--alt">
             <div class="container">
                 <div class="section-header">
                     <h2>Resources by Type</h2>
-                    <p>Looking for a specific type of resource? Browse by category.</p>
+                    <p>Know what you need but not which book it came from? Start here.</p>
                 </div>
                 <div class="resources-grid">
                     <div class="resource-card">
-                        <span class="resource-type download">Templates</span>
-                        <h3>Templates &amp; Frameworks</h3>
-                        <p>Business model canvases, project planning templates, decision frameworks, and strategic planning documents used throughout the series. Available as editable Google Docs, Notion templates, and spreadsheets.</p>
-                        <a href="#book-resources" class="btn btn-secondary">Browse Templates</a>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path><path d="M12 15V3"></path></svg>
+                            </span>
+                            <span class="resource-type download">Templates</span>
+                        </div>
+                        <h3>Templates &amp; Starter Kits</h3>
+                        <p>Importable automation blueprints, pre-configured MCP servers, and the starter packs that get a first working build in front of you the same day.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/no-code-ai-bible/templates.html">32 Make, Zapier &amp; n8n templates</a></li>
+                            <li><a href="books/mcp-blueprint/starter-kit.html">MCP Starter Kit</a></li>
+                            <li><a href="books/no-code-ai-bible/chapter-1.html">No-Code AI Starter Pack</a></li>
+                        </ul>
+                        <a href="books/no-code-ai-bible/templates.html" class="btn btn-secondary">Browse Templates</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type video">Video</span>
-                        <h3>Video Walkthroughs</h3>
-                        <p>Step-by-step video tutorials for the most complex topics in each book. Watch implementations being built from scratch, tool setups, and architecture discussions with the authors.</p>
-                        <a href="https://www.youtube.com/@NiuexaChampion" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Watch Videos</a>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="2"></rect><path d="M8 6h8"></path><path d="M8 11h.01"></path><path d="M12 11h.01"></path><path d="M16 11h.01"></path><path d="M8 16h4"></path></svg>
+                            </span>
+                            <span class="resource-type">Tools</span>
+                        </div>
+                        <h3>Calculators &amp; Interactive Tools</h3>
+                        <p>Run your own numbers before you commit budget. Payback periods, monthly tool spend, and the readiness score that tells you where to start.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/one-person-empire/roi-calculator.html">AI Automation ROI Calculator</a></li>
+                            <li><a href="books/one-person-empire/stack.html">The $215/Month Stack Breakdown</a></li>
+                            <li><a href="/en/roi-calculator.html">Niuexa ROI Calculator</a></li>
+                        </ul>
+                        <a href="books/one-person-empire/roi-calculator.html" class="btn btn-secondary">Run the Numbers</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type download">Checklists</span>
-                        <h3>Checklists &amp; Audits</h3>
-                        <p>Security audit checklists, deployment readiness assessments, business launch checklists, and quality assurance frameworks. Print them, check them off, and ship with confidence.</p>
-                        <a href="#book-resources" class="btn btn-secondary">Get Checklists</a>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 11 3 3L22 4"></path><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path></svg>
+                            </span>
+                            <span class="resource-type download">Checklists</span>
+                        </div>
+                        <h3>Checklists &amp; Runbooks</h3>
+                        <p>Print them, work down them, and do not ship until every box is checked. Plus the runbook for the day something breaks in production.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/ai-agents-field-guide/checklist.html">Agent Production Readiness Checklist</a></li>
+                            <li><a href="books/ai-agents-field-guide/runbook.html">Incident Response Runbook</a></li>
+                            <li><a href="books/mcp-blueprint/roadmap-template.html">90-Day Rollout Roadmap</a></li>
+                        </ul>
+                        <a href="books/ai-agents-field-guide/checklist.html" class="btn btn-secondary">Get Checklists</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type community">Community</span>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m4 8 4-4 4 4"></path><path d="M8 4v9a3 3 0 0 0 3 3h3"></path><rect x="14" y="13" width="7" height="7" rx="1"></rect></svg>
+                            </span>
+                            <span class="resource-type community">Prompts</span>
+                        </div>
                         <h3>Prompt Libraries</h3>
-                        <p>Curated collections of production-tested prompts organized by use case. Marketing prompts, coding prompts, analysis prompts, and agent system prompts — all copy-paste ready.</p>
-                        <a href="#book-resources" class="btn btn-secondary">Browse Prompts</a>
+                        <p>Production-tested prompts organized by the job they do — sales outreach, research, reporting, and the system prompts behind working agents.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/one-person-empire/prompts.html">Production-Ready Agent Prompts</a></li>
+                            <li><a href="books/one-person-empire/sales-demo.html">AI Sales Rep Demo Preview</a></li>
+                            <li><a href="/en/learn.html">Prompting tutorials and guides</a></li>
+                        </ul>
+                        <a href="books/one-person-empire/prompts.html" class="btn btn-secondary">Browse Prompts</a>
                     </div>
                     <div class="resource-card">
-                        <span class="resource-type">Comparisons</span>
-                        <h3>Tool Comparison Matrices</h3>
-                        <p>Side-by-side comparisons of AI tools, platforms, and services. Pricing, features, limitations, and recommendations — updated quarterly as the tool landscape evolves.</p>
-                        <a href="#book-resources" class="btn btn-secondary">View Comparisons</a>
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><rect x="7" y="12" width="3" height="6"></rect><rect x="13" y="8" width="3" height="10"></rect><rect x="19" y="5" width="2" height="13"></rect></svg>
+                            </span>
+                            <span class="resource-type">Comparisons</span>
+                        </div>
+                        <h3>Tool Comparisons &amp; Pricing</h3>
+                        <p>Side-by-side comparisons of the platforms the books rely on — features, limits and current pricing, re-checked as vendors move their tiers around.</p>
+                        <ul class="resource-features">
+                            <li><a href="nocode-toolkit.html">No-Code AI Toolkit pricing guide</a></li>
+                            <li><a href="books/ai-agents-field-guide/frameworks.html">Agent Framework Comparison 2026</a></li>
+                            <li><a href="books/mcp-blueprint/breaches.html">AI Security Breach Timeline</a></li>
+                        </ul>
+                        <a href="nocode-toolkit.html" class="btn btn-secondary">View Comparisons</a>
+                    </div>
+                    <div class="resource-card">
+                        <div class="resource-card-head">
+                            <span class="resource-icon" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"></rect><path d="m10 9 5 3-5 3z"></path></svg>
+                            </span>
+                            <span class="resource-type video">Video</span>
+                        </div>
+                        <h3>Video Walkthroughs &amp; Demos</h3>
+                        <p>Watch the builds happen. Step-by-step implementations, tool setups, and architecture discussions for the topics that read hardest on the page.</p>
+                        <ul class="resource-features">
+                            <li><a href="books/no-code-ai-bible/demo.html">Building an AI Automation Live</a></li>
+                            <li><a href="books/one-person-empire/sales-demo.html">AI Sales Rep Demo</a></li>
+                            <li><a href="https://www.youtube.com/@NiuexaChampion" target="_blank" rel="noopener noreferrer">Niuexa on YouTube</a></li>
+                        </ul>
+                        <a href="https://www.youtube.com/@NiuexaChampion" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Watch Videos</a>
                     </div>
                 </div>
             </div>
         </section>
 
         <!-- Updates Info -->
-        <section class="series-intro" style="background: var(--light-gray);">
+        <section class="series-intro">
             <div class="container">
                 <h2>Always Up to Date</h2>
                 <p>AI tools and best practices evolve rapidly. Every resource in this library is reviewed and updated quarterly. When a tool changes its API, a better approach emerges, or new capabilities become available, we update the companion materials and notify you via the newsletter. Your resources never go stale.</p>
-                <p style="margin-top: 15px;">Last resource update: <strong>March 2026</strong> &middot; Reviewed periodically as tools and best practices evolve</p>
+                <p>Last resource update: <strong>August 2026</strong> &middot; Reviewed periodically as tools and best practices evolve</p>
             </div>
         </section>
 
@@ -299,7 +446,7 @@
             </div>
         </section>
 
-        <p class="content-last-updated">Last updated: March 2026</p>
+        <p class="content-last-updated">Last updated: August 2026</p>
     </main>
 
     <!-- Footer Placeholder -->
@@ -307,7 +454,8 @@
 
     <!-- Scripts -->
     <script src="script.js?v=20260428"></script>
-    <script src="/en/includes/navigation-en.js"></script>
+    <script src="/en/includes/navigation-en.js?v=20260811"></script>
+    <script src="conversion-tracking.js?v=20260707"></script>
     <script src="cookie-banner.js?v=20260428"></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -32,7 +32,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/ai-operator-series.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
@@ -322,7 +322,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/books/ai-agents-field-guide/resources.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
@@ -337,7 +337,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/books/mcp-blueprint/resources.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
@@ -367,7 +367,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/books/no-code-ai-bible/resources.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
@@ -382,7 +382,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/books/one-person-empire/resources.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
@@ -422,7 +422,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/community.html</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
@@ -647,7 +647,7 @@
   </url>
   <url>
     <loc>https://niuexa.ai/resources.html</loc>
-    <lastmod>2026-07-14</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <priority>0.8</priority>
   </url>
   <url>


### PR DESCRIPTION
`resources.html` was visually out of step with the rest of the site and advertised destinations that did not exist. This brings it onto the shared design system, makes every link resolve, and surfaces the 14 companion pages the hub was hiding.

## UI/UX alignment

- **Inline styles removed.** The page carried 18 inline-styled `<li>` elements and 2 inline section backgrounds. These are now reusable `books.css` components: `.resource-features`, `.resource-icon`, `.resource-card-head`, `.hub-stats`, `.resources-section--alt`. The checkmark markers were coloured with `--primary-green`, a fill token that misses WCAG AA as text — they now use `--green-text`.
- **Card icons and a stats band added**, matching the card language already used on the community and consulting pages. The page previously had no icons anywhere.
- **Book cards move to a two-up grid.** The `auto-fit` grid fitted three 300px tracks inside the 1200px container, stranding the fourth book card alone on its own row.
- **Section bands now alternate** white/tinted instead of running two whites together.
- `community.html` and `ai-operator-series.html` adopt the same extracted components, so the inline-style pattern is gone from the cluster.

## Broken links

- **Three dead GitHub cards.** `github.com/gregormaric` does not exist as an account, so all three "View on GitHub" buttons 404'd. They now point at the full resource library — which also gives the book pages the back-link to the hub they never had.
- **Four dead-end CTAs.** In "Resources by Type", 4 of 5 buttons ("Browse Templates", "Get Checklists", "Browse Prompts", "View Comparisons") were `#book-resources` anchors that just scrolled back up the page. The section is now a real directory of 6 categories, every link resolving to an actual page.
- **14 unreachable pages.** The hub surfaced only the 4 book landing pages. The starter kit, 32 templates, ROI calculator, prompt library, readiness checklist, framework comparison, incident runbook and the rest were not linked from it at all. All 18 are now reachable.
- `ai-operator-series.html` sent all four book "Resources" buttons to the shared hub instead of each book's own library.
- One-Person Empire still listed "GitHub repository access" as a bundle feature after its GitHub card was removed.

## Navigation

`getCurrentPage()` in `en/includes/navigation-en.js` had no branch for `resources.html` or `/books/`, so it fell through to `'home'` — the entire AI Operator Series cluster highlighted **Home** in the navbar instead of **Resources › Free Resources**. The EN nav's `data-page="free-resources"` was never matched by anything.

## Also in this change

The AI Agents Field Guide resources page used an inline-styled CTA putting `--primary-blue` text on white (borderline for AA). It now uses the shared `.book-cta` component, with a new `.btn-ghost` variant so a banner can carry two actions without two identical solid buttons.

`books.css` cache-buster bumped on all 23 pages that link it, and `sitemap.xml` lastmod updated for the 7 changed content pages.

## Verification

- `axe-core` (WCAG 2.1 A + AA): **0 violations** at 1440px and 390px on `resources.html`, `community.html`, `ai-operator-series.html`, and the book resource pages
- No horizontal overflow at either breakpoint
- All 33 unique internal URLs across the 7 touched pages return 200
- Nav active-state verified across 17 pages, no regression on `/en/`
- All JSON-LD blocks and `sitemap.xml` parse

## Notes for review

- `ai-operator-course.html` still advertises "GitHub repository access" and "All GitHub repositories" as course deliverables. These are claims in sales copy rather than links, so I left them — worth deciding whether repos will exist or the copy should change.
- The Italian nav links `/resources.html` as "Risorse Gratuite", but the page and its destinations are English. Left as-is; translating the cluster is a larger call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBHzZJkSKMNFAfCPouq9nb)_